### PR TITLE
feat: drop support for Node.js 18

### DIFF
--- a/.changeset/itchy-views-sip.md
+++ b/.changeset/itchy-views-sip.md
@@ -1,0 +1,7 @@
+---
+"storycap-testrun": major
+---
+
+**BREAKING CHANGE**: Drop support for Node.js 18. The minimum required Node.js version is now 20.
+
+This change aligns with Node.js LTS lifecycle and ensures better compatibility with modern tooling.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -23,7 +23,7 @@ jobs:
     needs: [setup]
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -42,7 +42,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Furthermore, it provides heuristic utilities for avoiding flaky tests, such as M
 
 ## Requirements
 
-- Node.js >= 18
+- Node.js >= 20
 - [`@storybook/test-runner`][storybook-test-runner] >= 0.x
 
 ## Installation


### PR DESCRIPTION
## Summary
- Drop support for Node.js 18
- Set minimum required Node.js version to 20
- Update CI workflow to only test on Node.js 20
- Update README requirements

## Test plan
- [x] CI workflow passes with Node.js 20 only
- [x] Build succeeds
- [x] Tests pass
- [x] Changeset added for breaking change

🤖 Generated with [Claude Code](https://claude.ai/code)