### PR TITLE
chore: migrate Prettier configuration from package.json to prettier.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,6 @@
     "test": "pnpm test:e2e",
     "test:e2e": "zx scripts/e2e.js"
   },
-  "prettier": {
-    "plugins": [
-      "prettier-plugin-packagejson"
-    ],
-    "singleQuote": true
-  },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.1",
     "@changesets/cli": "2.29.4",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+export default {
+  plugins: ['prettier-plugin-packagejson'],
+  singleQuote: true,
+};


### PR DESCRIPTION
## Summary
- Move Prettier configuration from package.json to prettier.config.js
- Maintain existing configuration (singleQuote and prettier-plugin-packagejson)
- Verified configuration works with lint:prettier command

## Test plan
- [x] Prettier configuration loads correctly from prettier.config.js
- [x] All files pass prettier check
- [x] No breaking changes to existing formatting