### PR TITLE
refactor: make examples independent workspaces

### DIFF
--- a/examples/v7-react/pnpm-workspace.yaml
+++ b/examples/v7-react/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/examples/v8-react/pnpm-workspace.yaml
+++ b/examples/v8-react/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -44,7 +44,7 @@ async function runE2ETest(example) {
       await fs.rm('node_modules', { recursive: true, force: true });
 
       // All commands run within the example directory
-      await $`pnpm install --ignore-workspace`;
+      await $`pnpm install`;
 
       // Install Playwright browsers for each example
       // CI: install without system deps (already installed via ci.yaml)


### PR DESCRIPTION
## Summary

This PR refactors the example projects to operate as completely independent workspaces, improving test isolation and providing a cleaner development experience.

## Changes

- **Added empty `pnpm-workspace.yaml`** to each example directory (`examples/v7-react/` and `examples/v8-react/`)
  - Each example now acts as its own workspace root
  - No longer inherits workspace configuration from parent project
- **Removed `--ignore-workspace` flag** from e2e test script (`scripts/e2e.js`)
  - Flag is no longer needed since each example is now an independent workspace
  - Simplifies the installation command

## Benefits

- **Better test isolation**: Each example runs in a completely independent environment
- **More realistic user experience**: Examples now behave like standalone projects that users would create
- **Cleaner e2e testing**: No need to override workspace behavior with flags
- **Improved maintainability**: Clear separation between the main project and example projects