### PR TITLE
ci: use env NODE_VERSION and build locally in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,12 +51,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: [setup]
+    env:
+      NODE_VERSION: 20
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - uses: ./.github/actions/setup-node
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
 
       - run: pnpm lint
 
@@ -82,10 +84,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: dist-${{ env.NODE_VERSION }}
-          path: packages
+      - run: pnpm build
 
       - name: Creating .npmrc
         run: |


### PR DESCRIPTION
- Define NODE_VERSION=20 in lint job
- Use ${{ env.NODE_VERSION }} in setup-node
- Replace artifact download with 'pnpm build' in publish job

Rationale: reduce coupling to artifacts, simplify CI, and keep Node version in one place.
