### PR TITLE
chore: exit canary mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "@storycap-testrun/browser": "1.0.0",


### PR DESCRIPTION
## Summary

Exit changeset pre-release mode to prepare for stable v2.0.0 release.

## Changes

- Change changeset mode from "pre" to "exit" in `.changeset/pre.json`
- This will prepare the changeset for the final v2.0.0 release

## Context

This completes the canary release phase and sets up for the stable v2.0.0 release with the major package restructuring and API changes.