### PR TITLE
chore: add publishConfig for public access to packages

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -64,6 +64,9 @@
   "peerDependencies": {
     "@vitest/browser": "*"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsdown": {
     "entry": [
       "src/index.ts",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -40,6 +40,9 @@
     "test:watch": "vitest",
     "typecheck": "tsc"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsdown": {
     "entry": [
       "src/index.ts"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -57,6 +57,9 @@
     "@storybook/test-runner": "*",
     "playwright": "*"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsdown": {
     "entry": [
       "src/index.ts"


### PR DESCRIPTION
## Summary

Add `publishConfig` with `"access": "public"` to all package.json files to ensure packages are published as public packages.

This change affects:
- `packages/browser/package.json`
- `packages/internal/package.json` 
- `packages/node/package.json`