### PR TITLE
ci: improve release workflow and package publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - run: npm i -g npm@latest
       - run: pnpm build
 
       - name: Create Release Pull Request


### PR DESCRIPTION
## Summary
- Add necessary workflow permissions for release automation
- Remove manual NPM token setup in favor of automated publishing
- Add publishConfig for public access to all packages  
- Install latest npm before build to ensure compatibility

This streamlines the release process by leveraging GitHub's built-in NPM publishing capabilities and ensures all packages are properly configured for public access.