### PR TITLE
ci: improve workflow security and visual regression settings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,6 @@ on:
 env:
   NODE_VERSION: 20
 
-permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
-
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -56,6 +51,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [setup]
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
     strategy:
       matrix:
         node: [20, 22, 24]
@@ -88,7 +87,7 @@ jobs:
         with:
           name: component-screenshots
           path: __screenshots__/
-          retention-days: 30
+          retention-days: 90
 
       - name: Visual Regression Test
         uses: reg-viz/reg-actions@480d59a2a63da144e914883346f5120f27701310 # v2
@@ -96,9 +95,10 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           image-directory-path: './__screenshots__'
-          matching-threshold: 0.1
-          threshold-rate: 0.02
+          outdated-comment-action: 'minimize'
           enable-antialias: true
+          retention-days: 90
+          threshold-pixel: 40
 
   pass:
     runs-on: ubuntu-latest
@@ -113,6 +113,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'reg-viz/storycap-testrun' && github.ref == 'refs/heads/main'
     needs: [pass]
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 


### PR DESCRIPTION
## Summary

- Move permissions from global to job-specific level for better security
- Update artifact retention from 30 to 90 days for better debugging
- Improve visual regression test configuration with new threshold and minimization settings

## Changes

- **Security**: Moved workflow permissions to job-specific level instead of global
- **Artifacts**: Extended retention period from 30 to 90 days for component screenshots
- **Visual Regression**: Updated reg-actions configuration:
  - Added `outdated-comment-action: minimize` to reduce PR noise
  - Replaced `matching-threshold` and `threshold-rate` with `threshold-pixel: 40`
  - Added `retention-days: 90` for visual regression artifacts