### PR TITLE
feat: add per-story image options, fix viewport scaling, and support fullPage capture

### DIFF
--- a/.changeset/per-story-image-options.md
+++ b/.changeset/per-story-image-options.md
@@ -1,0 +1,29 @@
+---
+'@storycap-testrun/internal': minor
+'@storycap-testrun/browser': minor
+'@storycap-testrun/node': minor
+---
+
+Add per-story image options and fix viewport/fullPage behavior in vitest browser mode.
+
+**Per-story image options**: `fullPage`, `omitBackground`, and `scale` can now be set per-story via `parameters.screenshot`, overriding the global defaults.
+
+```js
+export default {
+  parameters: {
+    screenshot: {
+      fullPage: false,
+    },
+  },
+};
+```
+
+**Viewport fix**: Added `viewport` option to the storycap plugin. This controls the screenshot capture dimensions, bypassing vitest's internal iframe scaling that previously caused screenshots to be captured at incorrect sizes.
+
+```js
+storycap({
+  viewport: { width: 1280, height: 720 },
+});
+```
+
+**Full-page capture**: `fullPage: true` (default) now correctly captures content that extends beyond the viewport by scrolling through the iframe and stitching the results. `fullPage: false` captures only the viewport area.

--- a/examples/v10-react-vite/stories/TallContent.jsx
+++ b/examples/v10-react-vite/stories/TallContent.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export const TallContent = () => (
+  <div>
+    <section
+      style={{
+        height: '100vh',
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <h1 style={{ color: 'white', fontSize: '48px' }}>Section 1</h1>
+    </section>
+    <section
+      style={{
+        height: '100vh',
+        background: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <h1 style={{ color: 'white', fontSize: '48px' }}>Section 2</h1>
+    </section>
+  </div>
+);

--- a/examples/v10-react-vite/stories/TallContent.stories.js
+++ b/examples/v10-react-vite/stories/TallContent.stories.js
@@ -1,0 +1,25 @@
+import { TallContent } from './TallContent';
+
+export default {
+  title: 'Example/TallContent',
+  component: TallContent,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+/**
+ * Default: fullPage true — captures both sections (height > viewport)
+ */
+export const FullPage = {};
+
+/**
+ * fullPage: false — captures only the viewport area (1280x720)
+ */
+export const ViewportOnly = {
+  parameters: {
+    screenshot: {
+      fullPage: false,
+    },
+  },
+};

--- a/examples/v10-react-vite/vitest.config.js
+++ b/examples/v10-react-vite/vitest.config.js
@@ -27,6 +27,10 @@ export default defineConfig({
             storybookScript: 'pnpm storybook --ci',
           }),
           storycap({
+            viewport: {
+              width: 1280,
+              height: 720,
+            },
             output: {
               file: (context) =>
                 path.join(

--- a/examples/v9-react-vite/vitest.config.js
+++ b/examples/v9-react-vite/vitest.config.js
@@ -27,6 +27,10 @@ export default defineConfig({
             storybookScript: 'pnpm storybook --ci',
           }),
           storycap({
+            viewport: {
+              width: 1280,
+              height: 720,
+            },
             output: {
               file: (context) =>
                 path.join(

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -67,6 +67,8 @@ This makes it ideal for teams who need more than basic screenshots - providing t
   - **Fallback**: Other browsers use hash verification only (still effective, but slower)
 - **Browser environment constraints**
   - Limited to capabilities available in browser context.
+- **Full-page screenshots with `position: fixed/sticky`**
+  - When capturing full-page screenshots of content taller than the viewport, elements with `position: fixed` or `position: sticky` may appear duplicated in the output image.
 
 ## Installation
 
@@ -88,6 +90,7 @@ Add the storycap plugin to your `vitest.config.js`:
 import path from 'node:path';
 import { defineConfig, defineProject } from 'vitest/config';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
 import storycap from '@storycap-testrun/browser/vitest-plugin';
 
 export default defineConfig({
@@ -100,14 +103,17 @@ export default defineConfig({
             storybookScript: 'storybook --ci',
           }),
           storycap({
-            // options...
+            viewport: {
+              width: 1280,
+              height: 720,
+            },
           }),
         ],
         test: {
           name: 'storybook',
           browser: {
             enabled: true,
-            provider: 'playwright',
+            provider: playwright(),
             headless: true,
             instances: [{ browser: 'chromium' }],
           },
@@ -124,7 +130,7 @@ export default defineConfig({
 Create `.storybook/vitest.setup.ts`:
 
 ```typescript
-import { afterEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
 import { page } from '@vitest/browser/context';
 import { screenshot } from '@storycap-testrun/browser';
 import { setProjectAnnotations } from '@storybook/react-vite'; // Adjust for your framework
@@ -132,17 +138,30 @@ import * as projectAnnotations from './preview';
 
 setProjectAnnotations([projectAnnotations]);
 
+// Recommended: set the viewport to match the storycap plugin's viewport option
+beforeEach(async () => {
+  await page.viewport(1280, 720);
+});
+
 afterEach(async (context) => {
   await screenshot(page, context);
 });
 ```
 
-**Why `afterEach`?**
+**`beforeEach` with `page.viewport()` (recommended)**
+
+The storycap plugin's `viewport` option controls the screenshot capture dimensions — screenshots will be taken at the specified size regardless of this setting. However, `page.viewport()` controls the viewport during **story rendering**, which affects:
+
+- **Responsive layouts**: Breakpoint-dependent rendering (e.g., mobile vs desktop)
+- **Viewport-relative CSS units**: `100vh`, `vw`, etc. are calculated based on this viewport size
+
+Without `page.viewport()`, stories render at Vitest's default iframe size (which varies by environment). For most cases, setting `page.viewport()` to match the plugin `viewport` produces the most accurate screenshots.
+
+**`afterEach` with `screenshot()`**
 
 - **Post-story state**: Captures the final state after all story rendering and play functions complete
 - **Test isolation**: Each story gets its own screenshot without interference from previous tests
 - **Automatic execution**: No need to manually call screenshot in every story file
-- **Consistent timing**: Ensures screenshots are taken at the same lifecycle point for all stories
 
 ### 3. Run Tests
 
@@ -202,8 +221,25 @@ The plugin bridges Vitest's test execution with screenshot capture, providing th
 ```typescript
 type VitestStorycapPluginOptions = {
   output?: ScreenshotOutputOptions<BrowserScreenshotContext>;
+  viewport?: { width: number; height: number };
 };
 ```
+
+##### `viewport`
+
+**Type:** `{ width: number; height: number }`
+**Default:** Uses the Playwright context viewport (typically 1280x720)
+
+Sets the viewport dimensions for screenshot capture. This ensures screenshots are captured at the specified dimensions regardless of Vitest's internal iframe scaling.
+
+```javascript
+storycap({
+  viewport: { width: 1280, height: 720 },
+});
+```
+
+> [!TIP]
+> Screenshots are captured at this size regardless of `page.viewport()`. However, it is recommended to also call `page.viewport()` in `beforeEach` with the same dimensions so that stories render at the correct viewport during the test. This matters for responsive layouts and viewport-relative CSS units like `100vh`.
 
 ##### `output.dir`
 
@@ -378,10 +414,44 @@ Masks elements corresponding to the CSS selector with a rectangle. Useful for hi
 
 ### `remove`
 
-**Type:** `string`  
+**Type:** `string`
 **Default:** None
 
 Removes elements corresponding to the CSS selector.
+
+### `fullPage`
+
+**Type:** `boolean`
+**Default:** `true`
+
+Captures the full scrollable content when `true`. When `false`, captures only the viewport area. Can be set per-story to override the global default set in `screenshot()` options.
+
+```typescript
+export const ViewportOnly = {
+  parameters: {
+    screenshot: {
+      fullPage: false,
+    },
+  },
+};
+```
+
+> [!NOTE]
+> When `fullPage` is `true` and content exceeds the viewport height, screenshots are captured by scrolling through the content and stitching the results. Elements with `position: fixed` or `position: sticky` may appear duplicated across tiles.
+
+### `omitBackground`
+
+**Type:** `boolean`
+**Default:** `false`
+
+Hides the default white background and allows capturing screenshots with transparency. Can be set per-story to override the global default.
+
+### `scale`
+
+**Type:** `'css' | 'device'`
+**Default:** `'device'`
+
+The screenshot resolution scale. `'css'` produces screenshots at CSS pixel dimensions, while `'device'` produces screenshots at device pixel dimensions (which may be larger on high-DPI displays). Can be set per-story to override the global default.
 
 ## CHANGELOG
 

--- a/packages/browser/src/screenshot.test.ts
+++ b/packages/browser/src/screenshot.test.ts
@@ -9,6 +9,9 @@ vi.mock('vitest/browser', () => ({
     resolveScreenshotFilepath: vi
       .fn()
       .mockResolvedValue('/test/screenshot.png'),
+    __storycap_takeScreenshot: vi
+      .fn()
+      .mockResolvedValue('base64-screenshot-data'),
   },
 }));
 
@@ -159,7 +162,8 @@ describe('createBrowserScreenshotAdapter', () => {
     expect(waitForStable).toHaveBeenCalledWith(context, options);
   });
 
-  test('should take screenshot with correct options', async () => {
+  test('should take screenshot via browser command', async () => {
+    const { commands } = await import('vitest/browser');
     const adapter = createBrowserScreenshotAdapter();
     const filepath = '/test/screenshot.png';
     const options = {
@@ -171,21 +175,17 @@ describe('createBrowserScreenshotAdapter', () => {
 
     const result = await adapter.takeScreenshot(mockPage, filepath, options);
 
-    expect(mockPage.screenshot).toHaveBeenCalledWith({
-      path: filepath,
-      save: true,
-      base64: true,
-      animations: 'disabled',
-      caret: 'hide',
+    expect(commands.__storycap_takeScreenshot).toHaveBeenCalledWith(filepath, {
       fullPage: true,
       omitBackground: false,
       scale: 'device',
       type: 'png',
     });
-    expect(result).toBe('base64screenshot');
+    expect(result).toBe('base64-screenshot-data');
   });
 
-  test('should take JPEG screenshot', async () => {
+  test('should take JPEG screenshot via browser command', async () => {
+    const { commands } = await import('vitest/browser');
     const adapter = createBrowserScreenshotAdapter();
     const filepath = '/test/screenshot.jpg';
     const options = {
@@ -197,12 +197,7 @@ describe('createBrowserScreenshotAdapter', () => {
 
     await adapter.takeScreenshot(mockPage, filepath, options);
 
-    expect(mockPage.screenshot).toHaveBeenCalledWith({
-      path: filepath,
-      save: true,
-      base64: true,
-      animations: 'disabled',
-      caret: 'hide',
+    expect(commands.__storycap_takeScreenshot).toHaveBeenCalledWith(filepath, {
       fullPage: false,
       omitBackground: true,
       scale: 'css',

--- a/packages/browser/src/screenshot.ts
+++ b/packages/browser/src/screenshot.ts
@@ -1,7 +1,11 @@
 import type { TestContext } from 'vitest';
 import type {
+  PrepareViewportParams,
+  PrepareViewportResult,
   ResolveScreenshotFilepathParams,
   ResolveScreenshotFilepathResult,
+  RestoreViewportParams,
+  RestoreViewportResult,
   TakeScreenshotParams,
   TakeScreenshotResult,
 } from './vitest-plugin';
@@ -26,6 +30,12 @@ declare module 'vitest/browser' {
     __storycap_takeScreenshot: (
       ...params: TakeScreenshotParams
     ) => TakeScreenshotResult;
+    __storycap_prepareViewport: (
+      ...params: PrepareViewportParams
+    ) => PrepareViewportResult;
+    __storycap_restoreViewport: (
+      ...params: RestoreViewportParams
+    ) => RestoreViewportResult;
   }
 }
 
@@ -115,6 +125,14 @@ export const createBrowserScreenshotAdapter = (): ScreenshotAdapter<
       scale: options.scale,
       type: options.type,
     });
+  },
+
+  prepareCapture: async () => {
+    await commands.__storycap_prepareViewport();
+  },
+
+  cleanupCapture: async () => {
+    await commands.__storycap_restoreViewport();
   },
 
   createAnimationsHook,

--- a/packages/browser/src/screenshot.ts
+++ b/packages/browser/src/screenshot.ts
@@ -2,6 +2,8 @@ import type { TestContext } from 'vitest';
 import type {
   ResolveScreenshotFilepathParams,
   ResolveScreenshotFilepathResult,
+  TakeScreenshotParams,
+  TakeScreenshotResult,
 } from './vitest-plugin';
 import type { BrowserPage } from 'vitest/browser';
 import { commands } from 'vitest/browser';
@@ -21,6 +23,9 @@ declare module 'vitest/browser' {
     resolveScreenshotFilepath: (
       ...params: ResolveScreenshotFilepathParams
     ) => ResolveScreenshotFilepathResult;
+    __storycap_takeScreenshot: (
+      ...params: TakeScreenshotParams
+    ) => TakeScreenshotResult;
   }
 }
 
@@ -103,19 +108,13 @@ export const createBrowserScreenshotAdapter = (): ScreenshotAdapter<
     await waitForStable(context, options);
   },
 
-  takeScreenshot: async (page, filepath, options) => {
-    const data = await page.screenshot({
-      path: filepath,
-      save: true,
-      base64: true,
-      animations: 'disabled',
-      caret: 'hide',
+  takeScreenshot: async (_page, filepath, options) => {
+    return commands.__storycap_takeScreenshot(filepath, {
       fullPage: options.fullPage,
       omitBackground: options.omitBackground,
       scale: options.scale,
       type: options.type,
     });
-    return data.base64;
   },
 
   createAnimationsHook,

--- a/packages/browser/src/vitest-plugin/index.ts
+++ b/packages/browser/src/vitest-plugin/index.ts
@@ -32,6 +32,66 @@ export type TakeScreenshotParams = [
 ];
 export type TakeScreenshotResult = Promise<string>;
 
+export type PrepareViewportParams = [];
+export type PrepareViewportResult = Promise<void>;
+
+export type RestoreViewportParams = [];
+export type RestoreViewportResult = Promise<void>;
+
+// Module-level state to store the original iframe wrapper style between
+// prepareViewport and restoreViewport calls within a single capture cycle.
+let savedOriginalStyle: string | null = null;
+
+/**
+ * Prepares the iframe viewport for screenshot capture.
+ * Sets the iframe wrapper to the configured viewport size with `transform: none`.
+ * Must be called before any hooks so that mask positions and user hooks
+ * see the correct layout dimensions.
+ */
+const createPrepareViewport =
+  (pluginViewport?: {
+    width: number;
+    height: number;
+  }): BrowserCommand<PrepareViewportParams> =>
+  async (context): PrepareViewportResult => {
+    const viewport = pluginViewport ??
+      context.page.viewportSize() ?? { width: 1280, height: 720 };
+
+    savedOriginalStyle = await context.page.evaluate(
+      ({ w, h }) => {
+        const iframe = document.querySelector(
+          'iframe[data-vitest]',
+        ) as HTMLIFrameElement | null;
+        const wrapper = iframe?.parentElement;
+        if (!wrapper) return null;
+
+        const original = wrapper.style.cssText;
+        wrapper.style.cssText = `width: ${w}px; height: ${h}px; transform: none; transform-origin: left top;`;
+        return original;
+      },
+      { w: viewport.width, h: viewport.height },
+    );
+  };
+
+/**
+ * Restores the iframe wrapper to its original state after screenshot capture.
+ */
+const restoreViewport: BrowserCommand<RestoreViewportParams> = async (
+  context,
+): RestoreViewportResult => {
+  if (savedOriginalStyle != null) {
+    await context.page.evaluate((css) => {
+      const iframe = document.querySelector(
+        'iframe[data-vitest]',
+      ) as HTMLIFrameElement | null;
+      if (iframe?.parentElement) {
+        iframe.parentElement.style.cssText = css;
+      }
+    }, savedOriginalStyle);
+    savedOriginalStyle = null;
+  }
+};
+
 /**
  * Captures a full-page screenshot by scrolling through the iframe and stitching
  * viewport-sized clips using the browser's Canvas API.
@@ -125,19 +185,8 @@ async function captureFullPage(
 }
 
 /**
- * Creates a browser command that takes screenshots via Playwright's frame API,
- * bypassing vitest's orchestrator CSS transform scaling.
- *
- * Vitest browser renders tests inside an iframe whose wrapper element may have
- * `transform: scale(...)` applied when the requested viewport exceeds the
- * orchestrator container's available space. This causes `locator.screenshot()`
- * to capture at the visual (scaled) size instead of the DOM-level size.
- *
- * This command works around the issue by:
- * 1. Reading the viewport from plugin config (or falling back to context viewport)
- * 2. Setting the iframe wrapper to that exact size with `transform: none`
- * 3. Taking the screenshot at the correct DOM dimensions
- * 4. Restoring the original iframe wrapper styles
+ * Creates a browser command that takes screenshots.
+ * The iframe wrapper CSS is already adjusted by prepareViewport before this runs.
  */
 const createTakeScreenshot =
   (pluginViewport?: {
@@ -148,113 +197,77 @@ const createTakeScreenshot =
     const viewport = pluginViewport ??
       context.page.viewportSize() ?? { width: 1280, height: 720 };
 
-    // Set iframe wrapper to the configured viewport size without CSS transform
-    const originalStyle = await context.page.evaluate(
-      ({ w, h }) => {
-        const iframe = document.querySelector(
-          'iframe[data-vitest]',
-        ) as HTMLIFrameElement | null;
-        const wrapper = iframe?.parentElement;
-        if (!wrapper) return null;
+    let buffer: Buffer;
 
-        const original = wrapper.style.cssText;
-        wrapper.style.cssText = `width: ${w}px; height: ${h}px; transform: none; transform-origin: left top;`;
-        return original;
-      },
-      { w: viewport.width, h: viewport.height },
-    );
+    if (options.fullPage === false) {
+      // Viewport-only capture via clip on the orchestrator page
+      await context.page.evaluate(() => window.scrollTo(0, 0));
 
-    try {
-      let buffer: Buffer;
+      const iframeBox = await context.page
+        .locator('iframe[data-vitest]')
+        .boundingBox();
+      if (!iframeBox) {
+        throw new Error(
+          'Could not determine iframe position for viewport screenshot',
+        );
+      }
 
-      if (options.fullPage === false) {
-        // Playwright's locator.screenshot() always captures the full element
-        // (equivalent to fullPage: true). To support fullPage: false, we capture
-        // the orchestrator page with a clip region targeting the iframe's viewport
-        // area. Coordinates are in CSS pixels (Playwright handles DPR internally).
-        await context.page.evaluate(() => window.scrollTo(0, 0));
-
-        const iframeBox = await context.page
-          .locator('iframe[data-vitest]')
-          .boundingBox();
-        if (!iframeBox) {
-          throw new Error(
-            'Could not determine iframe position for viewport screenshot',
-          );
-        }
-
-        buffer = Buffer.from(
-          await context.page.screenshot({
-            animations: 'disabled',
-            caret: 'hide',
-            clip: {
-              x: iframeBox.x,
-              y: iframeBox.y,
-              width: iframeBox.width,
-              height: iframeBox.height,
-            },
-            ...(options.omitBackground != null && {
-              omitBackground: options.omitBackground,
-            }),
-            ...(options.scale != null && { scale: options.scale }),
-            ...(options.type != null && { type: options.type }),
+      buffer = Buffer.from(
+        await context.page.screenshot({
+          animations: 'disabled',
+          caret: 'hide',
+          clip: {
+            x: iframeBox.x,
+            y: iframeBox.y,
+            width: iframeBox.width,
+            height: iframeBox.height,
+          },
+          ...(options.omitBackground != null && {
+            omitBackground: options.omitBackground,
           }),
+          ...(options.scale != null && { scale: options.scale }),
+          ...(options.type != null && { type: options.type }),
+        }),
+      );
+    } else {
+      // Full-page capture: stitch if content exceeds viewport
+      const scrollHeight = await context.iframe
+        .locator('body')
+        .evaluate((body) =>
+          Math.max(
+            body.scrollHeight,
+            body.ownerDocument.documentElement.scrollHeight,
+          ),
+        );
+
+      if (scrollHeight > viewport.height) {
+        buffer = await captureFullPage(
+          context,
+          viewport,
+          scrollHeight,
+          options,
         );
       } else {
-        // Default: capture the full body element (equivalent to fullPage: true).
-        // Playwright's locator.screenshot() on a scrollable container only renders
-        // currently visible content. When content exceeds the viewport, we scroll
-        // through the iframe capturing viewport-sized clips, then stitch them
-        // using the browser's Canvas API (no external image library needed).
-        const scrollHeight = await context.iframe
+        const screenshotOptions: Parameters<
+          ReturnType<typeof context.iframe.locator>['screenshot']
+        >[0] = {
+          animations: 'disabled',
+          caret: 'hide',
+        };
+        if (options.omitBackground != null)
+          screenshotOptions.omitBackground = options.omitBackground;
+        if (options.scale != null) screenshotOptions.scale = options.scale;
+        if (options.type != null) screenshotOptions.type = options.type;
+        buffer = await context.iframe
           .locator('body')
-          .evaluate((body) =>
-            Math.max(
-              body.scrollHeight,
-              body.ownerDocument.documentElement.scrollHeight,
-            ),
-          );
-
-        if (scrollHeight > viewport.height) {
-          buffer = await captureFullPage(
-            context,
-            viewport,
-            scrollHeight,
-            options,
-          );
-        } else {
-          const screenshotOptions: Parameters<
-            ReturnType<typeof context.iframe.locator>['screenshot']
-          >[0] = {
-            animations: 'disabled',
-            caret: 'hide',
-          };
-          if (options.omitBackground != null)
-            screenshotOptions.omitBackground = options.omitBackground;
-          if (options.scale != null) screenshotOptions.scale = options.scale;
-          if (options.type != null) screenshotOptions.type = options.type;
-          buffer = await context.iframe
-            .locator('body')
-            .screenshot(screenshotOptions);
-        }
-      }
-
-      await fs.mkdir(path.dirname(filepath), { recursive: true });
-      await fs.writeFile(filepath, buffer);
-
-      return Buffer.from(buffer).toString('base64');
-    } finally {
-      if (originalStyle != null) {
-        await context.page.evaluate((css) => {
-          const iframe = document.querySelector(
-            'iframe[data-vitest]',
-          ) as HTMLIFrameElement | null;
-          if (iframe?.parentElement) {
-            iframe.parentElement.style.cssText = css;
-          }
-        }, originalStyle);
+          .screenshot(screenshotOptions);
       }
     }
+
+    await fs.mkdir(path.dirname(filepath), { recursive: true });
+    await fs.writeFile(filepath, buffer);
+
+    return Buffer.from(buffer).toString('base64');
   };
 
 /**
@@ -291,6 +304,8 @@ export default function vitestStorycapPluginOptions(
                 opts.output,
               ),
               __storycap_takeScreenshot: createTakeScreenshot(opts.viewport),
+              __storycap_prepareViewport: createPrepareViewport(opts.viewport),
+              __storycap_restoreViewport: restoreViewport,
             },
           },
         },

--- a/packages/browser/src/vitest-plugin/index.ts
+++ b/packages/browser/src/vitest-plugin/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { BrowserCommand } from 'vitest/node';
 import type { Plugin } from 'vitest/config';
@@ -20,15 +21,252 @@ const createResolveScreenshotFilepath =
     return path.join(output.dir, filename);
   };
 
+export type TakeScreenshotParams = [
+  filepath: string,
+  options: {
+    fullPage?: boolean;
+    omitBackground?: boolean;
+    scale?: 'css' | 'device';
+    type?: 'jpeg' | 'png';
+  },
+];
+export type TakeScreenshotResult = Promise<string>;
+
+/**
+ * Captures a full-page screenshot by scrolling through the iframe and stitching
+ * viewport-sized clips using the browser's Canvas API.
+ */
+async function captureFullPage(
+  context: Parameters<BrowserCommand<TakeScreenshotParams>>[0],
+  viewport: { width: number; height: number },
+  scrollHeight: number,
+  options: TakeScreenshotParams[1],
+): Promise<Buffer> {
+  const chunks: string[] = [];
+  const chunkHeights: number[] = [];
+
+  for (let scrollY = 0; scrollY < scrollHeight; scrollY += viewport.height) {
+    await context.iframe
+      .locator('body')
+      .evaluate(
+        (body, y) => body.ownerDocument.defaultView?.scrollTo(0, y),
+        scrollY,
+      );
+
+    const remaining = scrollHeight - scrollY;
+    const chunkH = Math.min(viewport.height, remaining);
+
+    const iframeBox = await context.page
+      .locator('iframe[data-vitest]')
+      .boundingBox();
+    if (!iframeBox) {
+      throw new Error(
+        'Could not determine iframe position for full-page screenshot',
+      );
+    }
+
+    const chunkBuf = await context.page.screenshot({
+      clip: {
+        x: iframeBox.x,
+        y: iframeBox.y,
+        width: iframeBox.width,
+        height: chunkH,
+      },
+      animations: 'disabled',
+      caret: 'hide',
+      ...(options.omitBackground != null && {
+        omitBackground: options.omitBackground,
+      }),
+      ...(options.scale != null && { scale: options.scale }),
+      ...(options.type != null && { type: options.type }),
+    });
+
+    chunks.push(Buffer.from(chunkBuf).toString('base64'));
+    chunkHeights.push(chunkH);
+  }
+
+  // Stitch chunks using browser-native Canvas API (no external dependency)
+  const mimeType = options.type === 'jpeg' ? 'image/jpeg' : 'image/png';
+  const stitchedB64 = await context.page.evaluate(
+    async ({ images, width, heights, mime }) => {
+      const totalH = heights.reduce((a, b) => a + b, 0);
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = totalH;
+      const ctx = canvas.getContext('2d')!;
+
+      let y = 0;
+      for (let i = 0; i < images.length; i++) {
+        const img = new Image();
+        img.src = `data:${mime};base64,${images[i]}`;
+        await new Promise<void>((r) => {
+          img.onload = () => r();
+        });
+        ctx.drawImage(img, 0, y);
+        y += heights[i] ?? 0;
+      }
+
+      return canvas.toDataURL(mime).split(',')[1] ?? '';
+    },
+    {
+      images: chunks,
+      width: viewport.width,
+      heights: chunkHeights,
+      mime: mimeType,
+    },
+  );
+
+  // Restore scroll position
+  await context.iframe
+    .locator('body')
+    .evaluate((body) => body.ownerDocument.defaultView?.scrollTo(0, 0));
+
+  return Buffer.from(stitchedB64, 'base64');
+}
+
+/**
+ * Creates a browser command that takes screenshots via Playwright's frame API,
+ * bypassing vitest's orchestrator CSS transform scaling.
+ *
+ * Vitest browser renders tests inside an iframe whose wrapper element may have
+ * `transform: scale(...)` applied when the requested viewport exceeds the
+ * orchestrator container's available space. This causes `locator.screenshot()`
+ * to capture at the visual (scaled) size instead of the DOM-level size.
+ *
+ * This command works around the issue by:
+ * 1. Reading the viewport from plugin config (or falling back to context viewport)
+ * 2. Setting the iframe wrapper to that exact size with `transform: none`
+ * 3. Taking the screenshot at the correct DOM dimensions
+ * 4. Restoring the original iframe wrapper styles
+ */
+const createTakeScreenshot =
+  (pluginViewport?: {
+    width: number;
+    height: number;
+  }): BrowserCommand<TakeScreenshotParams> =>
+  async (context, filepath, options): TakeScreenshotResult => {
+    const viewport = pluginViewport ??
+      context.page.viewportSize() ?? { width: 1280, height: 720 };
+
+    // Set iframe wrapper to the configured viewport size without CSS transform
+    const originalStyle = await context.page.evaluate(
+      ({ w, h }) => {
+        const iframe = document.querySelector(
+          'iframe[data-vitest]',
+        ) as HTMLIFrameElement | null;
+        const wrapper = iframe?.parentElement;
+        if (!wrapper) return null;
+
+        const original = wrapper.style.cssText;
+        wrapper.style.cssText = `width: ${w}px; height: ${h}px; transform: none; transform-origin: left top;`;
+        return original;
+      },
+      { w: viewport.width, h: viewport.height },
+    );
+
+    try {
+      let buffer: Buffer;
+
+      if (options.fullPage === false) {
+        // Playwright's locator.screenshot() always captures the full element
+        // (equivalent to fullPage: true). To support fullPage: false, we capture
+        // the orchestrator page with a clip region targeting the iframe's viewport
+        // area. Coordinates are in CSS pixels (Playwright handles DPR internally).
+        await context.page.evaluate(() => window.scrollTo(0, 0));
+
+        const iframeBox = await context.page
+          .locator('iframe[data-vitest]')
+          .boundingBox();
+        if (!iframeBox) {
+          throw new Error(
+            'Could not determine iframe position for viewport screenshot',
+          );
+        }
+
+        buffer = Buffer.from(
+          await context.page.screenshot({
+            animations: 'disabled',
+            caret: 'hide',
+            clip: {
+              x: iframeBox.x,
+              y: iframeBox.y,
+              width: iframeBox.width,
+              height: iframeBox.height,
+            },
+            ...(options.omitBackground != null && {
+              omitBackground: options.omitBackground,
+            }),
+            ...(options.scale != null && { scale: options.scale }),
+            ...(options.type != null && { type: options.type }),
+          }),
+        );
+      } else {
+        // Default: capture the full body element (equivalent to fullPage: true).
+        // Playwright's locator.screenshot() on a scrollable container only renders
+        // currently visible content. When content exceeds the viewport, we scroll
+        // through the iframe capturing viewport-sized clips, then stitch them
+        // using the browser's Canvas API (no external image library needed).
+        const scrollHeight = await context.iframe
+          .locator('body')
+          .evaluate((body) =>
+            Math.max(
+              body.scrollHeight,
+              body.ownerDocument.documentElement.scrollHeight,
+            ),
+          );
+
+        if (scrollHeight > viewport.height) {
+          buffer = await captureFullPage(
+            context,
+            viewport,
+            scrollHeight,
+            options,
+          );
+        } else {
+          const screenshotOptions: Parameters<
+            ReturnType<typeof context.iframe.locator>['screenshot']
+          >[0] = {
+            animations: 'disabled',
+            caret: 'hide',
+          };
+          if (options.omitBackground != null)
+            screenshotOptions.omitBackground = options.omitBackground;
+          if (options.scale != null) screenshotOptions.scale = options.scale;
+          if (options.type != null) screenshotOptions.type = options.type;
+          buffer = await context.iframe
+            .locator('body')
+            .screenshot(screenshotOptions);
+        }
+      }
+
+      await fs.mkdir(path.dirname(filepath), { recursive: true });
+      await fs.writeFile(filepath, buffer);
+
+      return Buffer.from(buffer).toString('base64');
+    } finally {
+      if (originalStyle != null) {
+        await context.page.evaluate((css) => {
+          const iframe = document.querySelector(
+            'iframe[data-vitest]',
+          ) as HTMLIFrameElement | null;
+          if (iframe?.parentElement) {
+            iframe.parentElement.style.cssText = css;
+          }
+        }, originalStyle);
+      }
+    }
+  };
+
 /**
  * Configuration options for Vitest screenshot plugin
  */
 export type VitestStorycapPluginOptions = {
   output?: ScreenshotOutputOptions<BrowserScreenshotContext>;
+  viewport?: { width: number; height: number };
 };
 
 /**
- * Vitest plugin that adds screenshot filepath resolution command to browser context
+ * Vitest plugin that adds screenshot capture commands to browser context
  */
 export default function vitestStorycapPluginOptions(
   options: VitestStorycapPluginOptions = {},
@@ -52,6 +290,7 @@ export default function vitestStorycapPluginOptions(
               resolveScreenshotFilepath: createResolveScreenshotFilepath(
                 opts.output,
               ),
+              __storycap_takeScreenshot: createTakeScreenshot(opts.viewport),
             },
           },
         },

--- a/packages/internal/src/parameters.test.ts
+++ b/packages/internal/src/parameters.test.ts
@@ -10,6 +10,9 @@ describe('resolveScreenshotParameters', () => {
       delay: null,
       mask: null,
       remove: null,
+      fullPage: null,
+      omitBackground: null,
+      scale: null,
     });
   });
 
@@ -25,6 +28,9 @@ describe('resolveScreenshotParameters', () => {
       delay: 1000,
       mask: null,
       remove: '.selector',
+      fullPage: null,
+      omitBackground: null,
+      scale: null,
     });
   });
 
@@ -49,6 +55,38 @@ describe('resolveScreenshotParameters', () => {
     expect(result.mask).toEqual({
       selector: '.custom-selector',
       color: '#ff00ff',
+    });
+  });
+
+  test('should override fullPage with false', () => {
+    const result = resolveScreenshotParameters({
+      fullPage: false,
+    });
+
+    expect(result).toEqual({
+      skip: false,
+      delay: null,
+      mask: null,
+      remove: null,
+      fullPage: false,
+      omitBackground: null,
+      scale: null,
+    });
+  });
+
+  test('should override scale with css', () => {
+    const result = resolveScreenshotParameters({
+      scale: 'css',
+    });
+
+    expect(result).toEqual({
+      skip: false,
+      delay: null,
+      mask: null,
+      remove: null,
+      fullPage: null,
+      omitBackground: null,
+      scale: 'css',
     });
   });
 

--- a/packages/internal/src/parameters.ts
+++ b/packages/internal/src/parameters.ts
@@ -16,6 +16,9 @@ export type ScreenshotParameters = {
   delay?: number | null;
   mask?: string | Partial<ScreenshotMaskConfig> | null;
   remove?: string | null;
+  fullPage?: boolean | null;
+  omitBackground?: boolean | null;
+  scale?: 'css' | 'device' | null;
 };
 
 /**
@@ -38,6 +41,9 @@ const defaultScreenshotParameters = {
   delay: null,
   mask: null,
   remove: null,
+  fullPage: null,
+  omitBackground: null,
+  scale: null,
 } satisfies ScreenshotParameters;
 
 /**

--- a/packages/internal/src/screenshot.test.ts
+++ b/packages/internal/src/screenshot.test.ts
@@ -283,6 +283,76 @@ describe('createScreenshotFunction', () => {
     );
   });
 
+  test('should override global fullPage with per-story fullPage: false', async () => {
+    mockAdapter.getParameters = vi.fn().mockResolvedValue({ fullPage: false });
+
+    const screenshotFn = createScreenshotFunction(mockAdapter);
+    const mockPage = { id: 'page-1' };
+    const mockContext = { testId: 'test-1' };
+
+    await screenshotFn(mockPage, mockContext);
+
+    expect(mockAdapter.takeScreenshot).toHaveBeenCalledWith(
+      mockPage,
+      '/test/screenshot.png',
+      expect.objectContaining({ fullPage: false }),
+    );
+  });
+
+  test('should override global scale with per-story scale: css', async () => {
+    mockAdapter.getParameters = vi.fn().mockResolvedValue({ scale: 'css' });
+
+    const screenshotFn = createScreenshotFunction(mockAdapter);
+    const mockPage = { id: 'page-1' };
+    const mockContext = { testId: 'test-1' };
+
+    await screenshotFn(mockPage, mockContext);
+
+    expect(mockAdapter.takeScreenshot).toHaveBeenCalledWith(
+      mockPage,
+      '/test/screenshot.png',
+      expect.objectContaining({ scale: 'css' }),
+    );
+  });
+
+  test('should use global defaults when per-story params are null', async () => {
+    mockAdapter.getParameters = vi.fn().mockResolvedValue({ fullPage: null });
+
+    const screenshotFn = createScreenshotFunction(mockAdapter);
+    const mockPage = { id: 'page-1' };
+    const mockContext = { testId: 'test-1' };
+
+    await screenshotFn(mockPage, mockContext);
+
+    expect(mockAdapter.takeScreenshot).toHaveBeenCalledWith(
+      mockPage,
+      '/test/screenshot.png',
+      expect.objectContaining({
+        fullPage: true,
+        omitBackground: false,
+        scale: 'device',
+      }),
+    );
+  });
+
+  test('should pass global image defaults when no per-story overrides', async () => {
+    const screenshotFn = createScreenshotFunction(mockAdapter);
+    const mockPage = { id: 'page-1' };
+    const mockContext = { testId: 'test-1' };
+
+    await screenshotFn(mockPage, mockContext);
+
+    expect(mockAdapter.takeScreenshot).toHaveBeenCalledWith(
+      mockPage,
+      '/test/screenshot.png',
+      expect.objectContaining({
+        fullPage: true,
+        omitBackground: false,
+        scale: 'device',
+      }),
+    );
+  });
+
   test('should apply delay when specified', async () => {
     mockAdapter.getParameters = vi.fn().mockResolvedValue({ delay: 100 });
 

--- a/packages/internal/src/screenshot.ts
+++ b/packages/internal/src/screenshot.ts
@@ -300,10 +300,19 @@ export const createScreenshotFunction = <
       ? 'jpeg'
       : 'png';
 
+    const imageOptions = {
+      ...opts.image,
+      ...(params.fullPage != null && { fullPage: params.fullPage }),
+      ...(params.omitBackground != null && {
+        omitBackground: params.omitBackground,
+      }),
+      ...(params.scale != null && { scale: params.scale }),
+    };
+
     await retakeScreenshotIfNeeded(
       async () => {
         return adapter.takeScreenshot(page, filepath, {
-          ...opts.image,
+          ...imageOptions,
           type,
         });
       },

--- a/packages/internal/src/screenshot.ts
+++ b/packages/internal/src/screenshot.ts
@@ -242,6 +242,18 @@ export type ScreenshotAdapter<
   createMaskingHook: (
     config: Required<ScreenshotMaskConfig>,
   ) => ScreenshotHook<Page, SContext>;
+
+  /**
+   * Prepares the capture environment before hooks run (e.g., adjust viewport/iframe).
+   * Called before hooks.setup() so that all user hooks see the correct layout.
+   */
+  prepareCapture?: (page: Page, context: SContext) => Promise<void>;
+
+  /**
+   * Restores the capture environment after the full capture flow completes.
+   * Always called in a finally block to guarantee cleanup even on errors.
+   */
+  cleanupCapture?: (page: Page, context: SContext) => Promise<void>;
 };
 
 /**
@@ -283,43 +295,53 @@ export const createScreenshotFunction = <
 
     const processor = createHookProcessor([...hooks, ...opts.hooks]);
 
-    await processor.setup(page, ctx);
+    // Prepare capture environment before any hooks run, so that all user hooks
+    // (setup, preCapture, postCapture) see the correct layout dimensions.
+    await adapter.prepareCapture?.(page, ctx);
 
-    await adapter.waitForStable(page, ctx, {
-      ...opts.flakiness.metrics,
-    });
+    try {
+      await processor.setup(page, ctx);
 
-    if (params.delay != null) {
-      await sleep(params.delay);
+      await adapter.waitForStable(page, ctx, {
+        ...opts.flakiness.metrics,
+      });
+
+      if (params.delay != null) {
+        await sleep(params.delay);
+      }
+
+      await processor.preCapture(page, ctx);
+
+      const filepath = await adapter.resolveFilepath(ctx);
+      const type = JPEG_EXTENSIONS.has(
+        filepath.slice(filepath.lastIndexOf('.')),
+      )
+        ? 'jpeg'
+        : 'png';
+
+      const imageOptions = {
+        ...opts.image,
+        ...(params.fullPage != null && { fullPage: params.fullPage }),
+        ...(params.omitBackground != null && {
+          omitBackground: params.omitBackground,
+        }),
+        ...(params.scale != null && { scale: params.scale }),
+      };
+
+      await retakeScreenshotIfNeeded(
+        async () => {
+          return adapter.takeScreenshot(page, filepath, {
+            ...imageOptions,
+            type,
+          });
+        },
+        adapter.createHash,
+        opts.flakiness,
+      );
+
+      await processor.postCapture(page, ctx, filepath);
+    } finally {
+      await adapter.cleanupCapture?.(page, ctx);
     }
-
-    await processor.preCapture(page, ctx);
-
-    const filepath = await adapter.resolveFilepath(ctx);
-    const type = JPEG_EXTENSIONS.has(filepath.slice(filepath.lastIndexOf('.')))
-      ? 'jpeg'
-      : 'png';
-
-    const imageOptions = {
-      ...opts.image,
-      ...(params.fullPage != null && { fullPage: params.fullPage }),
-      ...(params.omitBackground != null && {
-        omitBackground: params.omitBackground,
-      }),
-      ...(params.scale != null && { scale: params.scale }),
-    };
-
-    await retakeScreenshotIfNeeded(
-      async () => {
-        return adapter.takeScreenshot(page, filepath, {
-          ...imageOptions,
-          type,
-        });
-      },
-      adapter.createHash,
-      opts.flakiness,
-    );
-
-    await processor.postCapture(page, ctx, filepath);
   };
 };


### PR DESCRIPTION
## Summary

Addresses several issues reported in #230 regarding viewport sizing, per-story `fullPage` control, and DX when using `@storycap-testrun/browser` with `@storybook/addon-vitest`.

### Changes

**Per-story image options** (`@storycap-testrun/internal`)
- Added `fullPage`, `omitBackground`, and `scale` to `ScreenshotParameters`, allowing per-story overrides via `parameters.screenshot`
- Added merge logic in `createScreenshotFunction` to apply per-story values on top of global defaults (using `!= null` guards to preserve `fullPage: false`)

**Viewport fix & fullPage support** (`@storycap-testrun/browser`)
- Added `viewport` plugin option to `storycap()` — controls screenshot capture dimensions, bypassing vitest's internal iframe `transform: scale()` that caused screenshots to be captured at incorrect sizes (e.g., 960x720 instead of 1280x720)
- Replaced vitest's `page.screenshot()` (which internally uses `locator("body").screenshot()`) with a custom browser command that:
  - Sets the iframe wrapper to the configured viewport with `transform: none`
  - Supports `fullPage: false` via `page.screenshot({ clip })` on the orchestrator page
  - Supports `fullPage: true` with scroll + clip + Canvas API stitching for content beyond the viewport (no external image library needed)

**Documentation** (`packages/browser/README.md`)
- Added `viewport` plugin option documentation with usage guidance
- Added `fullPage`, `omitBackground`, `scale` to the Parameters section
- Updated Getting Started examples with `viewport` and `page.viewport()` setup pattern
- Added known limitation for `position: fixed/sticky` in full-page captures

**Examples**
- Added `TallContent` test story (two `100vh` sections) to verify fullPage behavior
- Updated `v10-react-vite` and `v9-react-vite` configs to use `storycap({ viewport })` instead of `contextOptions.viewport`

## References

- Ref #230 (context enrichment is not addressed in this PR)

## Verification

| Scenario | Expected | Result |
|---|---|---|
| Regular stories (Button, Header, Page) | 1280x720 | ✅ |
| TallContent/FullPage (fullPage: true) | 1280x1440 (two 100vh sections) | ✅ |
| TallContent/ViewportOnly (fullPage: false) | 1280x720 (viewport only) | ✅ |
| v9-react-vite stories | 1280x720 | ✅ |
| Unit tests | 64/64 pass | ✅ |
| Build + typecheck + lint | All pass | ✅ |