### PR TITLE
fix(browser): emit vitest-plugin default export as value, not type (#266)

### DIFF
--- a/.changeset/fix-vitest-plugin-dts-type-only.md
+++ b/.changeset/fix-vitest-plugin-dts-type-only.md
@@ -1,0 +1,7 @@
+---
+'@storycap-testrun/browser': patch
+---
+
+Fix bundled `.d.mts` / `.d.cts` emitting `vitestStorycapPluginOptions` (the default export of `@storycap-testrun/browser/vitest-plugin`) as a type-only export, which caused `TS1362: cannot be used as a value because it was exported using 'export type'` in TypeScript consumers using `import storycap from "@storycap-testrun/browser/vitest-plugin"` from a `vitest.config.ts` (issue #266).
+
+The browser package build is now split into per-entry tsdown configurations (`tsdown.config.ts` with `defineConfig` array) so the upstream `rolldown-plugin-dts` shared-chunk re-export bug — which incorrectly tagged runtime values with the `type` modifier in the shared `index-XXXX.d.mts` chunk — is avoided. Runtime output is unchanged.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -61,7 +61,8 @@
     "clean": "rimraf dist",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc"
+    "typecheck": "tsc && pnpm typecheck:dist",
+    "typecheck:dist": "tsc -p test-types"
   },
   "dependencies": {
     "@storycap-testrun/internal": "workspace:*"
@@ -72,25 +73,5 @@
   },
   "peerDependencies": {
     "@vitest/browser-playwright": "*"
-  },
-  "tsdown": {
-    "clean": true,
-    "deps": {
-      "neverBundle": [
-        "vitest/browser"
-      ]
-    },
-    "dts": true,
-    "entry": [
-      "src/index.ts",
-      "src/vitest-plugin/index.ts"
-    ],
-    "format": [
-      "esm",
-      "cjs"
-    ],
-    "minify": true,
-    "sourcemap": false,
-    "splitting": false
   }
 }

--- a/packages/browser/test-types/dist-types-cjs.test-d.cts
+++ b/packages/browser/test-types/dist-types-cjs.test-d.cts
@@ -1,0 +1,12 @@
+// Regression guard for issue #266 (CJS consumer path / .d.cts side).
+// The original bug appeared in both dist/index-XXXX.d.mts and dist/index-XXXX.d.cts;
+// this file ensures the CJS-side declaration is also regression-protected.
+//
+// The .cts extension makes TypeScript's nodenext resolver pick up the sibling
+// `index.d.cts` from `import '../dist/vitest-plugin/index.cjs'` (the `require`
+// condition target of the package.json `exports` map for `./vitest-plugin`).
+//
+// Requires `pnpm build` to have populated `packages/browser/dist/`.
+import storycap from '../dist/vitest-plugin/index.cjs';
+
+void storycap();

--- a/packages/browser/test-types/dist-types-esm.test-d.mts
+++ b/packages/browser/test-types/dist-types-esm.test-d.mts
@@ -1,0 +1,12 @@
+// Regression guard for issue #266 (ESM consumer path / .d.mts side).
+// Mirrors the failing scenario from the issue: if the bundled `.d.mts` re-exports
+// the default as type-only, this file fails to compile with TS1362.
+//
+// The .mts extension makes TypeScript's nodenext resolver pick up the sibling
+// `index.d.mts` from `import '../dist/vitest-plugin/index.mjs'` (the `import`
+// condition target of the package.json `exports` map for `./vitest-plugin`).
+//
+// Requires `pnpm build` to have populated `packages/browser/dist/`.
+import storycap from '../dist/vitest-plugin/index.mjs';
+
+void storycap();

--- a/packages/browser/test-types/tsconfig.json
+++ b/packages/browser/test-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["es2023", "dom", "dom.iterable"],
+    "isolatedDeclarations": false,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.mts", "./**/*.cts"]
+}

--- a/packages/browser/tsdown.config.ts
+++ b/packages/browser/tsdown.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig([
+  {
+    clean: true,
+    deps: {
+      neverBundle: ['vitest/browser'],
+    },
+    dts: true,
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    minify: true,
+    sourcemap: false,
+    splitting: false,
+  },
+  {
+    clean: false,
+    deps: {
+      neverBundle: ['vitest/browser'],
+    },
+    dts: true,
+    entry: ['src/vitest-plugin/index.ts'],
+    format: ['esm', 'cjs'],
+    minify: true,
+    outDir: 'dist/vitest-plugin',
+    sourcemap: false,
+    splitting: false,
+  },
+]);


### PR DESCRIPTION
## Summary

[#266](https://github.com/reg-viz/storycap-testrun/issues/266) — `import storycap from "@storycap-testrun/browser/vitest-plugin"` failing with **TS1362** (`cannot be used as a value because it was exported using 'export type'`) in TypeScript consumers since `2.1.0`.

### Root cause

`tsdown@0.21.x` (via `rolldown-plugin-dts@0.22.5`) bundles the dts of multi-entry packages into a shared chunk (`dist/index-XXXX.d.{mts,cts}`). In that shared chunk, runtime values — including the `vitestStorycapPluginOptions` factory function and the `Plugin` type from `vitest/config` — are re-exported with the `type` modifier:

```ts
declare function vitestStorycapPluginOptions(...): Plugin$1;
export {
  ...,
  type vitestStorycapPluginOptions as u,  // ← BUG
  type Plugin$5 as v,                     // ← BUG
};
```

`dist/vitest-plugin/index.d.{mts,cts}` then re-exports `u` as `default`, so the consumer receives a type-only default. `@storycap-testrun/internal` and `@storycap-testrun/node` are unaffected because they have a single entry and never produce a shared chunk.

### Fix

Split `packages/browser` into per-entry `tsdown` builds via `defineConfig([…])`. Each entry now produces its own dts without a shared chunk, so the upstream tagging bug no longer applies. Runtime output (`.mjs` / `.cjs`) is unchanged.

A regression guard lives at `packages/browser/test-types/`:

- `dist-types-esm.test-d.mts` — `.mts` extension drives the `import` condition → `dist/vitest-plugin/index.d.mts`
- `dist-types-cjs.test-d.cts` — `.cts` extension drives the `require` condition → `dist/vitest-plugin/index.d.cts`

Both call the imported default in value position; if the dts ever regresses to a type-only re-export, `tsc` fails with TS1362.

The package's `typecheck` script now chains the new `typecheck:dist` (`"typecheck": "tsc && pnpm typecheck:dist"`), so CI's existing `pnpm build && pnpm typecheck` step picks up the regression guard automatically — no workflow changes needed.

### Verification

- Built dist no longer contains `type vitestStorycapPluginOptions` / `type Plugin$5`
- `pnpm typecheck` (which now runs `typecheck:dist`) exits 0
- `pnpm test:unit` 9 files / 64 tests pass
- `pnpm test:e2e v9-react-vite` produces 8 screenshots (runtime regression negative)

## References

- #266
- Reference upstream issues for the dts bundling pattern: [`sxzz/rolldown-plugin-dts#95`](https://github.com/sxzz/rolldown-plugin-dts/issues/95), [`#230`](https://github.com/sxzz/rolldown-plugin-dts/issues/230)
