### PR TITLE
ci: update changesets/action to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,9 +128,7 @@ jobs:
       - run: pnpm build
 
       - name: Create Release Pull Request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          publish: pnpm release
-          commit: 'chore: version packages'
+          publish-script: pnpm release
+          commit-message: 'chore: version packages'


### PR DESCRIPTION
The 3.0.0 release published all three packages to npm but left no git tags and no GitHub releases — and the job still reported success.

## Why

v1 works out what was published by scanning the publish script's stdout for `New tag: <pkg>@<version>`:

```js
let e = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
for (let t of A.stdout.split("\n")) { ...; u.push(i) }
n && await Promise.all(u.map(async e => { await t.pushTag(n); await NF(r, {...}) }))
```

That one list drives both the tag push and the release creation. Changesets CLI 2.31.1 printed those lines; 3.0.1 replaced them with a spinner:

```
◇  Successfully published:
@storycap-testrun/browser@3.0.0 …
◒  Creating git tags...
◇  Created git tags.
```

So the list came back empty, both steps were skipped, and nothing failed. The CLI moved to 3.0.1 in #288.

Upstream fixed this in v2.0.0: published packages are read from the file the CLI writes to `CHANGESETS_OUTPUT`, and the action now refuses to run against a CLI older than 3. This repository is on `@changesets/cli` 3.0.1, so v2 is the matching pair.

## Changes

- Pin `changesets/action` to `8488615` (v2.1.1), matching how every other action here is pinned
- Rename the inputs v2 renamed: `publish` → `publish-script`, `commit` → `commit-message`
- Drop the `env: GITHUB_TOKEN` block — v2 removed environment-variable token handling, and `github-token` already defaults to the workflow token that block was passing. Leaving it in place raises an error when it does not match the input

Release commits and tags now go through the GitHub API rather than the git CLI, so they arrive signed with GitHub's key. That is v2's default; `push-with-git-cli: true` would restore the old behaviour.

Nothing else needed adjusting: `NPM_TOKEN` is unused (publishing goes through Trusted Publishing), and `cwd` / `setup-git-user` / `version` / `title` / `branch` were never set.

## Verification

`publish` only runs on a push to `main`, so this PR exercises the YAML and the other jobs. After merge, the job runs with no pending changesets and should stop at `No changesets found` — that confirms the action loads and its inputs are accepted, but not the tag-and-release path itself. That one is only observable at the next release, which is worth checking by hand with `git ls-remote --tags origin` and `gh release list`.

The 3.0.0 tags and releases have been created manually against `28528ae`, matching the shape of the 2.1.1 set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019N9N6h7J16zXpVYXL2c3jQ