### PR TITLE
fix(browser): capture content wider than the viewport in full-page screenshots

### DIFF
--- a/.changeset/wide-content-stitching.md
+++ b/.changeset/wide-content-stitching.md
@@ -1,0 +1,7 @@
+---
+'@storycap-testrun/browser': patch
+---
+
+Capture content wider than the viewport in full-page screenshots
+
+`fullPage: true` only stitched vertically, so content wider than the viewport — horizontally scrollable tables, lists, and similar layouts — was silently cropped to the viewport width. Full-page capture now tiles both axes: it scrolls horizontally as well, and stitches the chunks row by row, producing images sized to the content's full `scrollWidth` x `scrollHeight`. Vertical-only content produces byte-identical output to the previous behavior, and `deviceScaleFactor` other than 1 keeps working.

--- a/examples/v10-react-vite/stories/WideContent.jsx
+++ b/examples/v10-react-vite/stories/WideContent.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+const COLUMNS = [
+  ['#e11', 'A 0-640'],
+  ['#1a1', 'B 640-1280'],
+  ['#11e', 'C 1280-1920'],
+];
+
+const cell = (bg, label, height) => (
+  <div
+    key={label}
+    style={{
+      width: 640,
+      height,
+      background: bg,
+      color: '#fff',
+      font: 'bold 48px serif',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: 'none',
+    }}
+  >
+    {label}
+  </div>
+);
+
+/**
+ * 1920px wide (3 columns x 640px), shorter than the viewport.
+ * Exercises horizontal-only stitching.
+ */
+export const WideContent = () => (
+  <div style={{ display: 'flex', width: 1920 }}>
+    {COLUMNS.map(([bg, label]) => cell(bg, label, 300))}
+  </div>
+);
+
+/**
+ * 1920px wide and 1440px tall (3 columns x 2 rows).
+ * Exercises stitching on both axes at once.
+ */
+export const WideAndTallContent = () => (
+  <div style={{ width: 1920 }}>
+    <div style={{ display: 'flex' }}>
+      {COLUMNS.map(([bg, label]) => cell(bg, `1 ${label}`, 720))}
+    </div>
+    <div style={{ display: 'flex' }}>
+      {COLUMNS.map(([bg, label]) => cell(bg, `2 ${label}`, 720))}
+    </div>
+  </div>
+);

--- a/examples/v10-react-vite/stories/WideContent.stories.js
+++ b/examples/v10-react-vite/stories/WideContent.stories.js
@@ -1,0 +1,19 @@
+import { WideAndTallContent, WideContent } from './WideContent';
+
+export default {
+  title: 'Example/WideContent',
+  component: WideContent,
+  parameters: { layout: 'fullscreen' },
+};
+
+/**
+ * Wide: fullPage true — captures the full 1920px width (width > viewport)
+ */
+export const Wide = {};
+
+/**
+ * WideAndTall: fullPage true — captures 1920x1440 content by tiling both axes
+ */
+export const WideAndTall = {
+  render: WideAndTallContent,
+};

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -68,7 +68,7 @@ This makes it ideal for teams who need more than basic screenshots - providing t
 - **Browser environment constraints**
   - Limited to capabilities available in browser context.
 - **Full-page screenshots with `position: fixed/sticky`**
-  - When capturing full-page screenshots of content taller than the viewport, elements with `position: fixed` or `position: sticky` may appear duplicated in the output image.
+  - When capturing full-page screenshots of content larger than the viewport, elements with `position: fixed` or `position: sticky` may appear duplicated in the output image.
 - **Incompatible with `browser.ui`**
   - The Vitest UI keeps mutating the page, so the CDP metrics never settle and every capture ends in `MetricsTimeoutError`. `browser.ui` is already off whenever `headless: true` is set.
 - **Only Chromium is exercised**
@@ -451,7 +451,7 @@ export const ViewportOnly = {
 ```
 
 > [!NOTE]
-> When `fullPage` is `true` and content exceeds the viewport height, screenshots are captured by scrolling through the content and stitching the results. Elements with `position: fixed` or `position: sticky` may appear duplicated across tiles.
+> When `fullPage` is `true` and content exceeds the viewport height or width, screenshots are captured by scrolling through the content and stitching the results. Elements with `position: fixed` or `position: sticky` may appear duplicated across tiles.
 
 ### `omitBackground`
 

--- a/packages/browser/src/vitest-plugin/index.ts
+++ b/packages/browser/src/vitest-plugin/index.ts
@@ -143,66 +143,78 @@ const restoreViewport: BrowserCommand<RestoreViewportParams> = async (
 
 /**
  * Captures a full-page screenshot by scrolling through the iframe and stitching
- * viewport-sized clips using the browser's Canvas API.
+ * viewport-sized clips using the browser's Canvas API. Content wider than the
+ * viewport is covered by scrolling horizontally as well, tiling row by row.
  */
 async function captureFullPage(
   context: Parameters<BrowserCommand<TakeScreenshotParams>>[0],
   viewport: { width: number; height: number },
-  scrollHeight: number,
+  scrollSize: { width: number; height: number },
   options: TakeScreenshotParams[1],
 ): Promise<Buffer> {
   const chunks: string[] = [];
+  const columns = Math.ceil(scrollSize.width / viewport.width);
 
-  for (let scrollY = 0; scrollY < scrollHeight; scrollY += viewport.height) {
-    // The browser clamps a scroll past the bottom, so the requested offset is
-    // read back rather than assumed: the last chunk sits at the bottom of the
-    // viewport, not at its top.
-    const reachedScrollY = await context.iframe
-      .locator('body')
-      .evaluate((body, y) => {
-        const view = body.ownerDocument.defaultView;
-        // A story that sets `scroll-behavior: smooth` would otherwise leave the
-        // read-back on the pre-scroll position.
-        view?.scrollTo({ top: y, left: 0, behavior: 'instant' });
-        return view?.scrollY ?? 0;
-      }, scrollY);
-
-    const remaining = scrollHeight - scrollY;
-    const chunkH = Math.min(viewport.height, remaining);
-    const chunkOffset = scrollY - reachedScrollY;
-
-    const iframeBox = await context.page
-      .locator('iframe[data-vitest]')
-      .boundingBox();
-    if (!iframeBox) {
-      throw new Error(
-        'Could not determine iframe position for full-page screenshot',
+  for (
+    let scrollY = 0;
+    scrollY < scrollSize.height;
+    scrollY += viewport.height
+  ) {
+    for (
+      let scrollX = 0;
+      scrollX < scrollSize.width;
+      scrollX += viewport.width
+    ) {
+      // The browser clamps a scroll past the edge, so the requested offset is
+      // read back rather than assumed: the last chunk sits at the bottom/right
+      // edge of the viewport, not at its top/left.
+      const reached = await context.iframe.locator('body').evaluate(
+        (body, { x, y }) => {
+          const view = body.ownerDocument.defaultView;
+          // A story that sets `scroll-behavior: smooth` would otherwise leave the
+          // read-back on the pre-scroll position.
+          view?.scrollTo({ top: y, left: x, behavior: 'instant' });
+          return { x: view?.scrollX ?? 0, y: view?.scrollY ?? 0 };
+        },
+        { x: scrollX, y: scrollY },
       );
+
+      const chunkW = Math.min(viewport.width, scrollSize.width - scrollX);
+      const chunkH = Math.min(viewport.height, scrollSize.height - scrollY);
+
+      const iframeBox = await context.page
+        .locator('iframe[data-vitest]')
+        .boundingBox();
+      if (!iframeBox) {
+        throw new Error(
+          'Could not determine iframe position for full-page screenshot',
+        );
+      }
+
+      const chunkBuf = await context.page.screenshot({
+        clip: {
+          x: iframeBox.x + (scrollX - reached.x),
+          y: iframeBox.y + (scrollY - reached.y),
+          width: chunkW,
+          height: chunkH,
+        },
+        animations: 'disabled',
+        caret: 'hide',
+        ...(options.omitBackground != null && {
+          omitBackground: options.omitBackground,
+        }),
+        ...(options.scale != null && { scale: options.scale }),
+        ...(options.type != null && { type: options.type }),
+      });
+
+      chunks.push(Buffer.from(chunkBuf).toString('base64'));
     }
-
-    const chunkBuf = await context.page.screenshot({
-      clip: {
-        x: iframeBox.x,
-        y: iframeBox.y + chunkOffset,
-        width: iframeBox.width,
-        height: chunkH,
-      },
-      animations: 'disabled',
-      caret: 'hide',
-      ...(options.omitBackground != null && {
-        omitBackground: options.omitBackground,
-      }),
-      ...(options.scale != null && { scale: options.scale }),
-      ...(options.type != null && { type: options.type }),
-    });
-
-    chunks.push(Buffer.from(chunkBuf).toString('base64'));
   }
 
   // Stitch chunks using browser-native Canvas API (no external dependency)
   const mimeType = options.type === 'jpeg' ? 'image/jpeg' : 'image/png';
   const stitchedB64 = await context.page.evaluate(
-    async ({ images, mime }) => {
+    async ({ images, columns: cols, mime }) => {
       // Sizing the canvas from the decoded chunks rather than the CSS-pixel
       // viewport keeps the stitched image correct under a `deviceScaleFactor`
       // other than 1, where each chunk comes back scaled.
@@ -221,15 +233,25 @@ async function captureFullPage(
         ),
       );
 
+      const firstRow = decoded.slice(0, cols);
+      const firstColumn = decoded.filter((_, index) => index % cols === 0);
       const canvas = document.createElement('canvas');
-      canvas.width = Math.max(...decoded.map((img) => img.naturalWidth));
-      canvas.height = decoded.reduce((sum, img) => sum + img.naturalHeight, 0);
+      canvas.width = firstRow.reduce((sum, img) => sum + img.naturalWidth, 0);
+      canvas.height = firstColumn.reduce(
+        (sum, img) => sum + img.naturalHeight,
+        0,
+      );
       const ctx = canvas.getContext('2d')!;
 
       let y = 0;
-      for (const img of decoded) {
-        ctx.drawImage(img, 0, y);
-        y += img.naturalHeight;
+      for (let row = 0; row * cols < decoded.length; row += 1) {
+        const rowImages = decoded.slice(row * cols, (row + 1) * cols);
+        let x = 0;
+        for (const img of rowImages) {
+          ctx.drawImage(img, x, y);
+          x += img.naturalWidth;
+        }
+        y += rowImages[0]!.naturalHeight;
       }
 
       // A canvas past the browser's maximum dimensions yields an empty data URL,
@@ -242,7 +264,7 @@ async function captureFullPage(
       }
       return encoded;
     },
-    { images: chunks, mime: mimeType },
+    { images: chunks, columns, mime: mimeType },
   );
 
   // Restore scroll position
@@ -303,23 +325,22 @@ const createTakeScreenshot =
         }),
       );
     } else {
-      // Full-page capture: stitch if content exceeds viewport
-      const scrollHeight = await context.iframe
+      // Full-page capture: stitch if content exceeds viewport in either axis
+      const scrollSize = await context.iframe
         .locator('body')
-        .evaluate((body) =>
-          Math.max(
-            body.scrollHeight,
-            body.ownerDocument.documentElement.scrollHeight,
-          ),
-        );
+        .evaluate((body) => {
+          const documentElement = body.ownerDocument.documentElement;
+          return {
+            width: Math.max(body.scrollWidth, documentElement.scrollWidth),
+            height: Math.max(body.scrollHeight, documentElement.scrollHeight),
+          };
+        });
 
-      if (scrollHeight > viewport.height) {
-        buffer = await captureFullPage(
-          context,
-          viewport,
-          scrollHeight,
-          options,
-        );
+      if (
+        scrollSize.height > viewport.height ||
+        scrollSize.width > viewport.width
+      ) {
+        buffer = await captureFullPage(context, viewport, scrollSize, options);
       } else {
         const screenshotOptions: Parameters<
           ReturnType<typeof context.iframe.locator>['screenshot']


### PR DESCRIPTION
## What was wrong

`fullPage: true` only stitched vertically. Content wider than the viewport — horizontally scrollable tables, wide lists, and similar layouts — was silently cropped to the viewport width. `@storycap-testrun/node` captures the full `scrollWidth` via Playwright's `fullPage`, so migrating from `@storybook/test-runner` to `@storybook/addon-vitest` silently shrinks every such screenshot.

## What changed

`captureFullPage` now tiles both axes. The scroll size is measured as `max(body, documentElement)` for both `scrollWidth` and `scrollHeight`, the capture loop scrolls horizontally within each row, and the chunks are stitched row by row on the canvas.

The existing behaviours are generalized rather than reimplemented:

- The scroll-clamp read-back from #292 applies to both axes: the reached `scrollX`/`scrollY` is read back and the clip shifted by the difference, so edge chunks that are not a whole multiple of the viewport stay correct.
- The canvas is still sized from the decoded chunks (not CSS pixels), so a `deviceScaleFactor` other than 1 keeps working: the first row supplies the total width, the first column the total height.
- Vertical-only content goes through the same code with a single column and produces identical output (verified below).

`examples/v10-react-vite` gains a `WideContent` story pair — `Wide` (1920px wide, shorter than the viewport; horizontal-only stitching) and `WideAndTall` (1920x1440; both axes) — which runs under all three existing projects (default, wide viewport, 2x scale factor).

