### PR TITLE
feat(browser): add a per-story viewport parameter to override the capture viewport

### DIFF
--- a/.changeset/tall-stories-resize.md
+++ b/.changeset/tall-stories-resize.md
@@ -1,0 +1,34 @@
+---
+'@storycap-testrun/internal': minor
+'@storycap-testrun/browser': minor
+---
+
+Add a per-story `viewport` parameter to override the capture viewport
+
+Stories that do not fit into the globally configured viewport — dialogs and
+other fixed-position overlays are the typical case — can now request their own
+capture size:
+
+```typescript
+export const TallDialog = {
+  parameters: {
+    screenshot: {
+      viewport: { height: 800 },
+    },
+  },
+};
+```
+
+Both dimensions are optional. An omitted dimension falls back to the plugin's
+`viewport` option (or the Playwright context viewport when the plugin option is
+not set), so a story can override only the height it needs while multiple runs
+with different widths keep their own width.
+
+The Playwright context is resized for the duration of the capture and restored
+afterwards. The `@storycap-testrun/node` package is unchanged: with
+`@storybook/test-runner`, the same result is achievable in userland via
+`page.setViewportSize()` in a `preVisit` hook.
+
+For adapter implementors: `ScreenshotAdapter.prepareCapture` gains a third
+`viewport` argument and `takeScreenshot` options gain a `viewport` field,
+carrying the per-story override.

--- a/examples/v10-react-vite/stories/TallContent.stories.js
+++ b/examples/v10-react-vite/stories/TallContent.stories.js
@@ -23,3 +23,16 @@ export const ViewportOnly = {
     },
   },
 };
+
+/**
+ * Per-story viewport override — keeps the configured width and captures the
+ * viewport area at 1000px height (vs the 720px default)
+ */
+export const ViewportOverride = {
+  parameters: {
+    screenshot: {
+      fullPage: false,
+      viewport: { height: 1000 },
+    },
+  },
+};

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -33,7 +33,7 @@
 **Developer experience:**
 
 - **Flexible file management**: Full control over screenshot paths and naming conventions
-- **Story-level configuration**: Per-story parameters for skip, delay, mask, and remove
+- **Story-level configuration**: Per-story parameters for skip, delay, mask, remove, and viewport
 - **Vitest plugin**: Seamless integration with Vitest's configuration and lifecycle
 
 **Performance optimizations:**
@@ -157,7 +157,7 @@ afterEach(async (context) => {
 
 `page.viewport()` sizes the Vitest iframe while your test body runs, so it is what play functions and interaction assertions see. It does not decide the screenshot dimensions: immediately before capturing, storycap lays the story out at the plugin's `viewport` size, and the image is taken at that size.
 
-Set it when a play function depends on the viewport. Otherwise the plugin's `viewport` option is the only setting that affects the captured image.
+Set it when a play function depends on the viewport. Otherwise the captured image size is controlled by the plugin's `viewport` option, optionally overridden per story with the [`viewport` parameter](#viewport-1).
 
 **`afterEach` with `screenshot()`**
 
@@ -253,6 +253,9 @@ browser: {
 
 > [!NOTE]
 > `page.viewport()` from `vitest/browser` does not change this size. It sizes the Vitest iframe during the test body only.
+
+> [!TIP]
+> Individual stories can override these dimensions with the per-story [`viewport` parameter](#viewport-1).
 
 > [!WARNING]
 > When the Playwright context has no viewport of its own — `contextOptions: { viewport: null }` — the resize is one-way: Playwright cannot turn viewport emulation back off, so the page keeps this size for the rest of the run. Give the context a viewport as above to avoid it.
@@ -466,6 +469,29 @@ Hides the default white background and allows capturing screenshots with transpa
 **Default:** `'device'`
 
 The screenshot resolution scale. `'css'` produces screenshots at CSS pixel dimensions, while `'device'` produces screenshots at device pixel dimensions (which may be larger on high-DPI displays). Can be set per-story to override the global default.
+
+### `viewport`
+
+**Type:** `{ width?: number; height?: number }`
+**Default:** None
+
+Overrides the viewport the screenshot is captured at, for this story only. Both dimensions are optional — an omitted dimension falls back to the plugin's `viewport` option (or the Playwright context viewport when the plugin option is not set). Useful for stories such as dialogs that do not fit into the globally configured viewport.
+
+```typescript
+export const TallDialog = {
+  parameters: {
+    screenshot: {
+      // Keep the configured width, capture at 800px height
+      viewport: { height: 800 },
+    },
+  },
+};
+```
+
+The Playwright context is resized to the resolved viewport for the duration of the capture and restored afterwards, so other stories are not affected.
+
+> [!WARNING]
+> The same one-way caveat as the plugin's `viewport` option applies: when the Playwright context has no viewport of its own (`contextOptions: { viewport: null }`), enabling viewport emulation cannot be undone and the page keeps the overridden size for the rest of the run. Give the context a viewport to avoid it.
 
 ## CHANGELOG
 

--- a/packages/browser/src/screenshot.test.ts
+++ b/packages/browser/src/screenshot.test.ts
@@ -12,6 +12,8 @@ vi.mock('vitest/browser', () => ({
     __storycap_takeScreenshot: vi
       .fn()
       .mockResolvedValue('base64-screenshot-data'),
+    __storycap_prepareViewport: vi.fn().mockResolvedValue(undefined),
+    __storycap_restoreViewport: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -171,6 +173,7 @@ describe('createBrowserScreenshotAdapter', () => {
       omitBackground: false,
       scale: 'device' as const,
       type: 'png' as const,
+      viewport: null,
     };
 
     const result = await adapter.takeScreenshot(mockPage, filepath, options);
@@ -180,6 +183,7 @@ describe('createBrowserScreenshotAdapter', () => {
       omitBackground: false,
       scale: 'device',
       type: 'png',
+      viewport: null,
     });
     expect(result).toBe('base64-screenshot-data');
   });
@@ -193,6 +197,7 @@ describe('createBrowserScreenshotAdapter', () => {
       omitBackground: true,
       scale: 'css' as const,
       type: 'jpeg' as const,
+      viewport: null,
     };
 
     await adapter.takeScreenshot(mockPage, filepath, options);
@@ -202,7 +207,38 @@ describe('createBrowserScreenshotAdapter', () => {
       omitBackground: true,
       scale: 'css',
       type: 'jpeg',
+      viewport: null,
     });
+  });
+
+  test('should forward per-story viewport override to browser commands', async () => {
+    const { commands } = await import('vitest/browser');
+    const adapter = createBrowserScreenshotAdapter();
+    const context = { id: 'test-id', name: 'test-name', file: 'test.ts' };
+    const viewport = { height: 800 };
+
+    await adapter.prepareCapture?.(mockPage, context, viewport);
+
+    expect(commands.__storycap_prepareViewport).toHaveBeenCalledWith(viewport);
+
+    await adapter.takeScreenshot(mockPage, '/test/screenshot.png', {
+      fullPage: true,
+      omitBackground: false,
+      scale: 'device',
+      type: 'png',
+      viewport,
+    });
+
+    expect(commands.__storycap_takeScreenshot).toHaveBeenCalledWith(
+      '/test/screenshot.png',
+      {
+        fullPage: true,
+        omitBackground: false,
+        scale: 'device',
+        type: 'png',
+        viewport,
+      },
+    );
   });
 
   test('should return hook creation functions', async () => {

--- a/packages/browser/src/screenshot.ts
+++ b/packages/browser/src/screenshot.ts
@@ -124,11 +124,12 @@ export const createBrowserScreenshotAdapter = (): ScreenshotAdapter<
       omitBackground: options.omitBackground,
       scale: options.scale,
       type: options.type,
+      viewport: options.viewport,
     });
   },
 
-  prepareCapture: async () => {
-    await commands.__storycap_prepareViewport();
+  prepareCapture: async (_page, _context, viewport) => {
+    await commands.__storycap_prepareViewport(viewport);
   },
 
   cleanupCapture: async () => {

--- a/packages/browser/src/vitest-plugin/index.test.ts
+++ b/packages/browser/src/vitest-plugin/index.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import storycap from './index';
+
+type Viewport = { width: number; height: number };
+
+const getCommands = (options?: Parameters<typeof storycap>[0]) => {
+  const plugin = storycap(options) as any;
+  return plugin.config().test.browser.commands;
+};
+
+const createMockContext = (initialViewport: Viewport | null) => {
+  let current = initialViewport;
+  const page = {
+    viewportSize: vi.fn(() => current),
+    setViewportSize: vi.fn(async (viewport: Viewport) => {
+      current = viewport;
+    }),
+    evaluate: vi.fn(async () => 'original-style'),
+  };
+  return { page } as any;
+};
+
+describe('__storycap_prepareViewport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('resizes to the plugin viewport when it differs from the page', async () => {
+    const commands = getCommands({
+      viewport: { width: 1366, height: 600 },
+    });
+    const context = createMockContext({ width: 1280, height: 720 });
+
+    await commands.__storycap_prepareViewport(context);
+
+    expect(context.page.setViewportSize).toHaveBeenCalledWith({
+      width: 1366,
+      height: 600,
+    });
+  });
+
+  test('per-story override wins over the plugin viewport', async () => {
+    const commands = getCommands({
+      viewport: { width: 1366, height: 600 },
+    });
+    const context = createMockContext({ width: 1366, height: 600 });
+
+    await commands.__storycap_prepareViewport(context, {
+      width: 375,
+      height: 800,
+    });
+
+    expect(context.page.setViewportSize).toHaveBeenCalledWith({
+      width: 375,
+      height: 800,
+    });
+  });
+
+  test('partial override keeps the other dimension from the plugin viewport', async () => {
+    const commands = getCommands({
+      viewport: { width: 1366, height: 600 },
+    });
+    const context = createMockContext({ width: 1366, height: 600 });
+
+    await commands.__storycap_prepareViewport(context, { height: 800 });
+
+    expect(context.page.setViewportSize).toHaveBeenCalledWith({
+      width: 1366,
+      height: 800,
+    });
+  });
+
+  test('partial override falls back to the page viewport without a plugin viewport', async () => {
+    const commands = getCommands();
+    const context = createMockContext({ width: 1280, height: 720 });
+
+    await commands.__storycap_prepareViewport(context, { height: 800 });
+
+    expect(context.page.setViewportSize).toHaveBeenCalledWith({
+      width: 1280,
+      height: 800,
+    });
+  });
+
+  test('does not resize when the override matches the current viewport', async () => {
+    const commands = getCommands({
+      viewport: { width: 1366, height: 600 },
+    });
+    const context = createMockContext({ width: 1366, height: 600 });
+
+    await commands.__storycap_prepareViewport(context, { height: 600 });
+
+    expect(context.page.setViewportSize).not.toHaveBeenCalled();
+  });
+
+  test('restoreViewport undoes an override resize', async () => {
+    const commands = getCommands({
+      viewport: { width: 1366, height: 600 },
+    });
+    const context = createMockContext({ width: 1366, height: 600 });
+
+    await commands.__storycap_prepareViewport(context, { height: 800 });
+    await commands.__storycap_restoreViewport(context);
+
+    expect(context.page.setViewportSize).toHaveBeenLastCalledWith({
+      width: 1366,
+      height: 600,
+    });
+  });
+
+  test('sizes the iframe wrapper to the resolved viewport', async () => {
+    const commands = getCommands({
+      viewport: { width: 1366, height: 600 },
+    });
+    const context = createMockContext({ width: 1366, height: 600 });
+
+    await commands.__storycap_prepareViewport(context, { height: 800 });
+
+    expect(context.page.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      w: 1366,
+      h: 800,
+    });
+  });
+});

--- a/packages/browser/src/vitest-plugin/index.ts
+++ b/packages/browser/src/vitest-plugin/index.ts
@@ -5,6 +5,7 @@ import type { Plugin } from 'vitest/config';
 import {
   resolveScreenshotFilename,
   type ScreenshotOutputOptions,
+  type ScreenshotViewportConfig,
 } from '@storycap-testrun/internal';
 import type { BrowserScreenshotContext } from '../context';
 
@@ -28,11 +29,14 @@ export type TakeScreenshotParams = [
     omitBackground?: boolean;
     scale?: 'css' | 'device';
     type?: 'jpeg' | 'png';
+    viewport?: ScreenshotViewportConfig | null;
   },
 ];
 export type TakeScreenshotResult = Promise<string>;
 
-export type PrepareViewportParams = [];
+export type PrepareViewportParams = [
+  viewportOverride?: ScreenshotViewportConfig | null,
+];
 export type PrepareViewportResult = Promise<void>;
 
 export type RestoreViewportParams = [];
@@ -52,6 +56,23 @@ const captureStates = new WeakMap<
 >();
 
 /**
+ * Resolves the viewport a capture is taken at. A per-story override wins over
+ * the plugin option, which wins over the live Playwright context viewport.
+ * The override is partial, so a story can change only one dimension.
+ */
+const resolveCaptureViewport = (
+  pluginViewport: { width: number; height: number } | undefined,
+  pageViewport: { width: number; height: number } | null,
+  override: ScreenshotViewportConfig | null | undefined,
+): { width: number; height: number } => {
+  const base = pluginViewport ?? pageViewport ?? { width: 1280, height: 720 };
+  return {
+    width: override?.width ?? base.width,
+    height: override?.height ?? base.height,
+  };
+};
+
+/**
  * Prepares the iframe viewport for screenshot capture.
  * Sets the iframe wrapper to the configured viewport size with `transform: none`.
  * Must be called before any hooks so that mask positions and user hooks
@@ -62,9 +83,13 @@ const createPrepareViewport =
     width: number;
     height: number;
   }): BrowserCommand<PrepareViewportParams> =>
-  async (context): PrepareViewportResult => {
-    const viewport = pluginViewport ??
-      context.page.viewportSize() ?? { width: 1280, height: 720 };
+  async (context, viewportOverride): PrepareViewportResult => {
+    const previousViewport = context.page.viewportSize();
+    const viewport = resolveCaptureViewport(
+      pluginViewport,
+      previousViewport,
+      viewportOverride,
+    );
 
     // Playwright intersects a screenshot `clip` with the browser viewport, so a
     // configured viewport wider or taller than the Playwright context viewport
@@ -74,10 +99,11 @@ const createPrepareViewport =
     // A null viewport means emulation is off and the page follows the real
     // window; enabling emulation there cannot be undone, so it only happens for
     // a viewport the caller actually asked for.
-    const previousViewport = context.page.viewportSize();
+    const hasOverride =
+      viewportOverride?.width != null || viewportOverride?.height != null;
     const resized =
       previousViewport == null
-        ? pluginViewport != null
+        ? pluginViewport != null || hasOverride
         : previousViewport.width !== viewport.width ||
           previousViewport.height !== viewport.height;
 
@@ -267,8 +293,11 @@ const createTakeScreenshot =
     height: number;
   }): BrowserCommand<TakeScreenshotParams> =>
   async (context, filepath, options): TakeScreenshotResult => {
-    const viewport = pluginViewport ??
-      context.page.viewportSize() ?? { width: 1280, height: 720 };
+    const viewport = resolveCaptureViewport(
+      pluginViewport,
+      context.page.viewportSize(),
+      options.viewport,
+    );
 
     let buffer: Buffer;
 

--- a/packages/internal/src/parameters.test.ts
+++ b/packages/internal/src/parameters.test.ts
@@ -13,6 +13,7 @@ describe('resolveScreenshotParameters', () => {
       fullPage: null,
       omitBackground: null,
       scale: null,
+      viewport: null,
     });
   });
 
@@ -31,6 +32,7 @@ describe('resolveScreenshotParameters', () => {
       fullPage: null,
       omitBackground: null,
       scale: null,
+      viewport: null,
     });
   });
 
@@ -71,6 +73,7 @@ describe('resolveScreenshotParameters', () => {
       fullPage: false,
       omitBackground: null,
       scale: null,
+      viewport: null,
     });
   });
 
@@ -87,7 +90,22 @@ describe('resolveScreenshotParameters', () => {
       fullPage: null,
       omitBackground: null,
       scale: 'css',
+      viewport: null,
     });
+  });
+
+  test('should pass through partial viewport override', () => {
+    const result = resolveScreenshotParameters({
+      viewport: { height: 800 },
+    });
+
+    expect(result.viewport).toEqual({ height: 800 });
+  });
+
+  test('should default viewport to null', () => {
+    const result = resolveScreenshotParameters({});
+
+    expect(result.viewport).toBeNull();
   });
 
   test('should allow custom mask color', () => {

--- a/packages/internal/src/parameters.ts
+++ b/packages/internal/src/parameters.ts
@@ -9,6 +9,16 @@ export type ScreenshotMaskConfig = {
 };
 
 /**
+ * Per-story viewport override for screenshot capture.
+ * Omitted dimensions fall back to the globally configured viewport,
+ * so a story can override only the height (or width) it needs.
+ */
+export type ScreenshotViewportConfig = {
+  width?: number;
+  height?: number;
+};
+
+/**
  * Optional parameters for controlling screenshot behavior
  */
 export type ScreenshotParameters = {
@@ -19,6 +29,7 @@ export type ScreenshotParameters = {
   fullPage?: boolean | null;
   omitBackground?: boolean | null;
   scale?: 'css' | 'device' | null;
+  viewport?: ScreenshotViewportConfig | null;
 };
 
 /**
@@ -44,6 +55,7 @@ const defaultScreenshotParameters = {
   fullPage: null,
   omitBackground: null,
   scale: null,
+  viewport: null,
 } satisfies ScreenshotParameters;
 
 /**

--- a/packages/internal/src/screenshot.ts
+++ b/packages/internal/src/screenshot.ts
@@ -2,7 +2,11 @@ import type { ScreenshotContext } from './context';
 import { RetakeExceededError } from './error';
 import type { ScreenshotHook } from './hook';
 import { createHookProcessor } from './hook';
-import type { ScreenshotParameters, ScreenshotMaskConfig } from './parameters';
+import type {
+  ScreenshotParameters,
+  ScreenshotMaskConfig,
+  ScreenshotViewportConfig,
+} from './parameters';
 import { resolveScreenshotParameters } from './parameters';
 import { sleep, type RequiredDeep } from './utility';
 
@@ -218,12 +222,16 @@ export type ScreenshotAdapter<
   ) => Promise<void>;
 
   /**
-   * Takes actual screenshot with specified options
+   * Takes actual screenshot with specified options.
+   * `viewport` carries the per-story viewport override, if any.
    */
   takeScreenshot: (
     page: Page,
     filepath: string,
-    options: RequiredDeep<ScreenshotImageOptions> & { type: 'jpeg' | 'png' },
+    options: RequiredDeep<ScreenshotImageOptions> & {
+      type: 'jpeg' | 'png';
+      viewport: ScreenshotViewportConfig | null;
+    },
   ) => Promise<any>;
 
   /**
@@ -246,8 +254,13 @@ export type ScreenshotAdapter<
   /**
    * Prepares the capture environment before hooks run (e.g., adjust viewport/iframe).
    * Called before hooks.setup() so that all user hooks see the correct layout.
+   * `viewport` carries the per-story viewport override, if any.
    */
-  prepareCapture?: (page: Page, context: SContext) => Promise<void>;
+  prepareCapture?: (
+    page: Page,
+    context: SContext,
+    viewport: ScreenshotViewportConfig | null,
+  ) => Promise<void>;
 
   /**
    * Restores the capture environment after the full capture flow completes.
@@ -298,7 +311,7 @@ export const createScreenshotFunction = <
     try {
       // Runs before the hooks so that mask positions and user hooks read the
       // layout dimensions the screenshot will actually be taken at.
-      await adapter.prepareCapture?.(page, ctx);
+      await adapter.prepareCapture?.(page, ctx, params.viewport);
 
       await processor.setup(page, ctx);
 
@@ -333,6 +346,7 @@ export const createScreenshotFunction = <
           return adapter.takeScreenshot(page, filepath, {
             ...imageOptions,
             type,
+            viewport: params.viewport,
           });
         },
         adapter.createHash,

--- a/packages/node/src/screenshot.test.ts
+++ b/packages/node/src/screenshot.test.ts
@@ -141,6 +141,7 @@ describe('createNodeScreenshotAdapter', () => {
       omitBackground: false,
       scale: 'device' as const,
       type: 'png' as const,
+      viewport: null,
     };
 
     const result = await adapter.takeScreenshot(mockPage, filepath, options);
@@ -165,6 +166,7 @@ describe('createNodeScreenshotAdapter', () => {
       omitBackground: true,
       scale: 'css' as const,
       type: 'jpeg' as const,
+      viewport: null,
     };
 
     await adapter.takeScreenshot(mockPage, filepath, options);


### PR DESCRIPTION
## Why

Both packages capture every story at a single viewport per run. With `@storybook/test-runner` that is only a soft limitation: userland can call `page.setViewportSize()` from a `preVisit` hook based on story parameters. With `@storybook/addon-vitest` there is no equivalent escape hatch — the test body runs inside the browser, `page.viewport()` only sizes the Vitest iframe, and immediately before capturing the plugin lays the story out at its configured `viewport` size. Stories that do not fit into the global viewport — dialogs and other `position: fixed` overlays are the typical case — come out cropped, and nothing in userland can fix it.

## What changed

Stories can now override the capture viewport through the existing `screenshot` parameters:

```typescript
export const TallDialog = {
  parameters: {
    screenshot: {
      viewport: { height: 800 },
    },
  },
};
```

Both dimensions are optional. An omitted dimension falls back to the plugin's `viewport` option, and to the Playwright context viewport when the plugin option is not set. This matters for setups that run the same stories under several projects with different widths (e.g. desktop/mobile): a story can pin only the height it needs while each run keeps its own width.

- `@storycap-testrun/internal`: `ScreenshotParameters` gains an optional partial `viewport`; `ScreenshotAdapter.prepareCapture` gains a third `viewport` argument and `takeScreenshot` options gain a `viewport` field.
- `@storycap-testrun/browser`: `__storycap_prepareViewport` / `__storycap_takeScreenshot` accept the override and resolve the effective viewport as `override ?? plugin option ?? context viewport`. The resize/restore mechanism from #293 is reused as-is, so the Playwright context is resized only for the duration of the capture and the one-way `viewport: null` caveat is unchanged (documented on the new parameter as well).
- `@storycap-testrun/node` is unchanged apart from test type updates — with test-runner the same result stays achievable in userland.

## Verification

Unit tests cover the parameter defaults, the adapter forwarding, and the command-side resolution (override wins, partial merge, no-op when sizes already match, restore undoes the resize).

`examples/v10-react-vite` gains a `TallContent/ViewportOverride` story (`{ height: 1000 }`, `fullPage: false`) that runs under all three existing projects and produces exactly the expected sizes: 1280x1000 (default, width kept), 1600x1000 (wide project, its own width kept), 2560x2000 (2x scale factor).