### PR TITLE
fix(examples): regenerate v10-react-vite lockfile

### DIFF
--- a/examples/v10-react-vite/pnpm-lock.yaml
+++ b/examples/v10-react-vite/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
         specifier: workspace:*
         version: link:../internal
     devDependencies:
-      '@types/node':
-        specifier: ^26.3.0
-        version: 26.4.0
       '@vitest/browser-playwright':
         specifier: 4.1.11
         version: 4.1.11(playwright@1.62.1)(vite@7.1.12(@types/node@26.4.0))(vitest@4.1.11)


### PR DESCRIPTION
## Summary

`examples/v10-react-vite/pnpm-lock.yaml` recorded a `@types/node: ^26.3.0` devDependency for the `../../packages/browser` importer, but `packages/browser/package.json` declares no such dependency. The entry was introduced by #303, most likely from a local workspace state that differs from the repository.

`scripts/e2e.js` runs `pnpm install` with `CI=true`, and pnpm enables `frozen-lockfile` by default in CI, so the mismatch aborts the install before any test runs:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with ../packages/browser/package.json

  Failure reason:
  specifiers in the lockfile don't match specifiers in package.json:
* 1 dependencies were removed: @types/node@^26.3.0
```

Regenerating the lockfile removes the stale entry. The diff is limited to those three lines; no package resolution changes.

## Verification

- `CI=true pnpm install --frozen-lockfile` in `examples/v10-react-vite` — fails on `main`, succeeds on this branch
- `CI=true pnpm test:e2e v10-react-vite` — passes, 42 screenshots captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xcqM2oCQ8GjAnfDotZXeG