### PR TITLE
fix(browser): viewport styles freeze (instead of stitching);

### DIFF
--- a/.changeset/wild-pugs-shout.md
+++ b/.changeset/wild-pugs-shout.md
@@ -1,0 +1,10 @@
+---
+'@storycap-testrun/browser': minor
+'@storycap-testrun/internal': minor
+---
+
+Capture full-page screenshots in a single shot instead of stitching tiles
+
+`fullPage: true` used to scroll the story iframe and stitch viewport-sized tiles, which re-rendered `position: sticky` and `position: fixed` elements into every tile and painted over the content behind them. The iframe is now grown to its content size and captured in one Playwright screenshot, with viewport-relative units pinned to their current pixel lengths so `100vh` does not grow along with it; a story whose size follows the viewport through JavaScript or a cross-origin stylesheet is still captured at the viewport size and logs a warning.
+
+All 51 screenshots in the example suite keep their exact dimensions, and only text antialiasing changes outside the sticky/fixed fix.

--- a/examples/v10-react-vite/stories/OverflowContent.jsx
+++ b/examples/v10-react-vite/stories/OverflowContent.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export const AbsoluteOverflowContent = () => (
+  <div>
+    <div
+      style={{
+        height: 400,
+        background: '#0aa',
+        color: '#fff',
+        font: 'bold 40px serif',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      In flow (0-400)
+    </div>
+    <div
+      style={{
+        position: 'absolute',
+        top: 1600,
+        left: 0,
+        width: 800,
+        height: 300,
+        background: '#a0a',
+        color: '#fff',
+        font: 'bold 40px serif',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      Absolute at 1600
+    </div>
+  </div>
+);

--- a/examples/v10-react-vite/stories/OverflowContent.stories.js
+++ b/examples/v10-react-vite/stories/OverflowContent.stories.js
@@ -1,0 +1,14 @@
+import { AbsoluteOverflowContent } from './OverflowContent';
+
+export default {
+  title: 'Example/OverflowContent',
+  component: AbsoluteOverflowContent,
+  parameters: { layout: 'fullscreen' },
+};
+
+/**
+ * Content that overflows the document via `position: absolute` rather than by
+ * flowing. `body.scrollHeight` sees it but the body *box* does not, so an
+ * element screenshot of `body` would clip it.
+ */
+export const AbsoluteOverflow = {};

--- a/examples/v10-react-vite/stories/StickyContent.jsx
+++ b/examples/v10-react-vite/stories/StickyContent.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+const rows = Array.from({ length: 12 }, (_, i) => i + 1);
+
+/**
+ * A sticky header over content taller than the viewport.
+ * Stitched captures repeat the header once per tile; a single capture
+ * should show it exactly once.
+ */
+export const StickyContent = () => (
+  <div>
+    <header
+      style={{
+        position: 'sticky',
+        top: 0,
+        height: 80,
+        background: '#111',
+        color: '#fff',
+        font: 'bold 32px serif',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      Sticky header
+    </header>
+    {rows.map((n) => (
+      <div
+        key={n}
+        style={{
+          height: 200,
+          background: n % 2 ? '#eee' : '#ccc',
+          font: 'bold 32px serif',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Row {n}
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * A `position: fixed` badge over content taller than the viewport.
+ */
+export const FixedContent = () => (
+  <div>
+    <div
+      style={{
+        position: 'fixed',
+        top: 20,
+        right: 20,
+        padding: '12px 24px',
+        background: '#c00',
+        color: '#fff',
+        font: 'bold 24px serif',
+        zIndex: 10,
+      }}
+    >
+      Fixed badge
+    </div>
+    {rows.map((n) => (
+      <div
+        key={n}
+        style={{
+          height: 200,
+          background: n % 2 ? '#eef' : '#cce',
+          font: 'bold 32px serif',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Row {n}
+      </div>
+    ))}
+  </div>
+);

--- a/examples/v10-react-vite/stories/StickyContent.stories.js
+++ b/examples/v10-react-vite/stories/StickyContent.stories.js
@@ -1,0 +1,19 @@
+import { FixedContent, StickyContent } from './StickyContent';
+
+export default {
+  title: 'Example/StickyContent',
+  component: StickyContent,
+  parameters: { layout: 'fullscreen' },
+};
+
+/**
+ * Sticky header over 2400px of rows — must appear exactly once.
+ */
+export const Sticky = {};
+
+/**
+ * `position: fixed` badge over 2400px of rows — must appear exactly once.
+ */
+export const Fixed = {
+  render: FixedContent,
+};

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -454,7 +454,7 @@ export const ViewportOnly = {
 ```
 
 > [!NOTE]
-> When `fullPage` is `true` and content exceeds the viewport height or width, screenshots are captured by scrolling through the content and stitching the results. Elements with `position: fixed` or `position: sticky` may appear duplicated across tiles.
+> When `fullPage` is `true` and content exceeds the viewport, the story's iframe is grown to the size of its content and captured in one screenshot, so `position: fixed` and `position: sticky` elements render exactly once. Viewport-relative units are pinned to their current pixel lengths while this happens, so `100vh` does not grow with the iframe. A length computed from `window.innerHeight` in JavaScript, or one in a cross-origin stylesheet, cannot be pinned — those stories are captured at the viewport size and log a warning naming the cropped axis.
 
 ### `omitBackground`
 

--- a/packages/browser/src/screenshot.test.ts
+++ b/packages/browser/src/screenshot.test.ts
@@ -12,8 +12,9 @@ vi.mock('vitest/browser', () => ({
     __storycap_takeScreenshot: vi
       .fn()
       .mockResolvedValue('base64-screenshot-data'),
-    __storycap_prepareViewport: vi.fn().mockResolvedValue(undefined),
-    __storycap_restoreViewport: vi.fn().mockResolvedValue(undefined),
+    __storycap_resolveViewport: vi
+      .fn()
+      .mockResolvedValue({ width: 1280, height: 720 }),
   },
 }));
 
@@ -179,11 +180,9 @@ describe('createBrowserScreenshotAdapter', () => {
     const result = await adapter.takeScreenshot(mockPage, filepath, options);
 
     expect(commands.__storycap_takeScreenshot).toHaveBeenCalledWith(filepath, {
-      fullPage: true,
       omitBackground: false,
       scale: 'device',
       type: 'png',
-      viewport: null,
     });
     expect(result).toBe('base64-screenshot-data');
   });
@@ -203,15 +202,13 @@ describe('createBrowserScreenshotAdapter', () => {
     await adapter.takeScreenshot(mockPage, filepath, options);
 
     expect(commands.__storycap_takeScreenshot).toHaveBeenCalledWith(filepath, {
-      fullPage: false,
       omitBackground: true,
       scale: 'css',
       type: 'jpeg',
-      viewport: null,
     });
   });
 
-  test('should forward per-story viewport override to browser commands', async () => {
+  test('should forward per-story viewport override when resolving the viewport', async () => {
     const { commands } = await import('vitest/browser');
     const adapter = createBrowserScreenshotAdapter();
     const context = { id: 'test-id', name: 'test-name', file: 'test.ts' };
@@ -219,25 +216,27 @@ describe('createBrowserScreenshotAdapter', () => {
 
     await adapter.prepareCapture?.(mockPage, context, viewport);
 
-    expect(commands.__storycap_prepareViewport).toHaveBeenCalledWith(viewport);
+    expect(commands.__storycap_resolveViewport).toHaveBeenCalledWith(viewport);
+  });
 
+  test('should capture the iframe element without fullPage', async () => {
+    const { commands } = await import('vitest/browser');
+    const adapter = createBrowserScreenshotAdapter();
+    const context = { id: 'test-id', name: 'test-name', file: 'test.ts' };
+
+    await adapter.prepareCapture?.(mockPage, context, null);
+    await adapter.fitCaptureToContent?.(mockPage, context, { fullPage: false });
     await adapter.takeScreenshot(mockPage, '/test/screenshot.png', {
-      fullPage: true,
+      fullPage: false,
       omitBackground: false,
       scale: 'device',
       type: 'png',
-      viewport,
+      viewport: null,
     });
 
     expect(commands.__storycap_takeScreenshot).toHaveBeenCalledWith(
       '/test/screenshot.png',
-      {
-        fullPage: true,
-        omitBackground: false,
-        scale: 'device',
-        type: 'png',
-        viewport,
-      },
+      expect.objectContaining({ type: 'png' }),
     );
   });
 

--- a/packages/browser/src/screenshot.ts
+++ b/packages/browser/src/screenshot.ts
@@ -1,11 +1,9 @@
 import type { TestContext } from 'vitest';
 import type {
-  PrepareViewportParams,
-  PrepareViewportResult,
   ResolveScreenshotFilepathParams,
   ResolveScreenshotFilepathResult,
-  RestoreViewportParams,
-  RestoreViewportResult,
+  ResolveViewportParams,
+  ResolveViewportResult,
   TakeScreenshotParams,
   TakeScreenshotResult,
 } from './vitest-plugin';
@@ -20,6 +18,15 @@ import type { BrowserScreenshotContext } from './context';
 import { createAnimationsHook } from './hooks/animation';
 import { createRemovalHook } from './hooks/removal';
 import { createMaskingHook } from './hooks/masking';
+import {
+  fitFrameToContent,
+  getCaptureFrame,
+  resizeCaptureFrame,
+  waitForReflow,
+  type CaptureFrame,
+  type Size,
+} from './viewport';
+import type { UnfreezeViewportUnits } from './viewport-units';
 import { waitForStable } from './wait-for-stable';
 
 declare module 'vitest/browser' {
@@ -30,12 +37,9 @@ declare module 'vitest/browser' {
     __storycap_takeScreenshot: (
       ...params: TakeScreenshotParams
     ) => TakeScreenshotResult;
-    __storycap_prepareViewport: (
-      ...params: PrepareViewportParams
-    ) => PrepareViewportResult;
-    __storycap_restoreViewport: (
-      ...params: RestoreViewportParams
-    ) => RestoreViewportResult;
+    __storycap_resolveViewport: (
+      ...params: ResolveViewportParams
+    ) => ResolveViewportResult;
   }
 }
 
@@ -88,58 +92,121 @@ export const createBrowserScreenshotAdapter = (): ScreenshotAdapter<
   BrowserPage,
   TestContextWithStory,
   BrowserScreenshotContext
-> => ({
-  createContext: (context) => ({
-    id: context.story.id,
-    file: context.task.file.name,
-    name: context.story.storyName,
-  }),
+> => {
+  // One adapter is built per capture, so this state cannot leak between
+  // stories, and it stays inside the tester, which means concurrently running
+  // test files cannot see each other's iframe either.
+  let captureFrame: CaptureFrame | null = null;
+  let originalFrameStyle: string | null = null;
+  let originalWrapperStyle: string | null = null;
+  let viewport: Size = { width: 0, height: 0 };
+  let unfreezeViewportUnits: UnfreezeViewportUnits | null = null;
 
-  getParameters: (_, context) => context.story.parameters?.['screenshot'] ?? {},
+  return {
+    createContext: (context) => ({
+      id: context.story.id,
+      file: context.task.file.name,
+      name: context.story.storyName,
+    }),
 
-  resolveFilepath: async (context) => {
-    return commands.resolveScreenshotFilepath(context);
-  },
+    getParameters: (_, context) =>
+      context.story.parameters?.['screenshot'] ?? {},
 
-  createHash: async (data) => {
-    const binary = atob(data);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-    const buffer = await window.crypto.subtle.digest('SHA-256', bytes);
+    resolveFilepath: async (context) => {
+      return commands.resolveScreenshotFilepath(context);
+    },
 
-    return Array.from(new Uint8Array(buffer))
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('');
-  },
+    createHash: async (data) => {
+      const binary = atob(data);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      const buffer = await window.crypto.subtle.digest('SHA-256', bytes);
 
-  waitForStable: async (_, context, options) => {
-    await waitForStable(context, options);
-  },
+      return Array.from(new Uint8Array(buffer))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    },
 
-  takeScreenshot: async (_page, filepath, options) => {
-    return commands.__storycap_takeScreenshot(filepath, {
-      fullPage: options.fullPage,
-      omitBackground: options.omitBackground,
-      scale: options.scale,
-      type: options.type,
-      viewport: options.viewport,
-    });
-  },
+    waitForStable: async (_, context, options) => {
+      await waitForStable(context, options);
+    },
 
-  prepareCapture: async (_page, _context, viewport) => {
-    await commands.__storycap_prepareViewport(viewport);
-  },
+    takeScreenshot: async (_page, filepath, options) => {
+      return commands.__storycap_takeScreenshot(filepath, {
+        omitBackground: options.omitBackground,
+        scale: options.scale,
+        type: options.type,
+      });
+    },
 
-  cleanupCapture: async () => {
-    await commands.__storycap_restoreViewport();
-  },
+    prepareCapture: async (_page, _context, override) => {
+      viewport = await commands.__storycap_resolveViewport(override);
 
-  createAnimationsHook,
-  createRemovalHook,
-  createMaskingHook,
-});
+      captureFrame = getCaptureFrame();
+      if (captureFrame == null) {
+        return;
+      }
+
+      // Captured before the first resize so cleanup can put back exactly what
+      // Vitest left here, including the scale it applies to fit the iframe on
+      // screen.
+      originalFrameStyle = captureFrame.frame.style.cssText;
+      originalWrapperStyle = captureFrame.wrapper?.style.cssText ?? null;
+
+      resizeCaptureFrame(captureFrame, viewport);
+      await waitForReflow();
+    },
+
+    fitCaptureToContent: async (_page, context, { fullPage }) => {
+      // Without `fullPage` the iframe is already sized to the viewport, which
+      // is exactly the region to capture.
+      if (!fullPage || captureFrame == null) {
+        return;
+      }
+
+      const { unfreeze, truncated } = await fitFrameToContent(
+        captureFrame,
+        viewport,
+      );
+      unfreezeViewportUnits = unfreeze;
+
+      if (truncated.length > 0) {
+        console.warn(
+          `[storycap] "${context.name}" is cropped to the viewport ` +
+            `(${truncated.join(' and ')}). Its size follows the viewport ` +
+            `through something this cannot pin — a length computed in ` +
+            `JavaScript from window.innerHeight/innerWidth, or a stylesheet ` +
+            `served cross-origin — so growing the frame to the content grew ` +
+            `the content with it. Give the story a fixed size to capture it ` +
+            `in full.`,
+        );
+      }
+    },
+
+    cleanupCapture: async () => {
+      // Undone before the frame is resized back so the story is never left
+      // holding pixel lengths that were derived from a viewport it no longer
+      // has.
+      unfreezeViewportUnits?.();
+      unfreezeViewportUnits = null;
+
+      if (captureFrame == null) {
+        return;
+      }
+      captureFrame.frame.style.cssText = originalFrameStyle ?? '';
+      if (captureFrame.wrapper != null) {
+        captureFrame.wrapper.style.cssText = originalWrapperStyle ?? '';
+      }
+      captureFrame = null;
+    },
+
+    createAnimationsHook,
+    createRemovalHook,
+    createMaskingHook,
+  };
+};
 
 /**
  * Captures screenshot in Vitest browser environment using Storybook test context

--- a/packages/browser/src/viewport-units.test.ts
+++ b/packages/browser/src/viewport-units.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, afterEach } from 'vitest';
+import { freezeValue, freezeViewportUnits } from './viewport-units';
+
+const VIEWPORT = { width: 1280, height: 720 };
+
+const addStyle = (css: string) => {
+  const style = document.createElement('style');
+  style.textContent = css;
+  document.head.appendChild(style);
+  return style;
+};
+
+const ruleOf = (style: HTMLStyleElement, index = 0) =>
+  (style.sheet!.cssRules[index] as CSSStyleRule).style;
+
+afterEach(() => {
+  document.head.querySelectorAll('style').forEach((el) => el.remove());
+  document.body.innerHTML = '';
+});
+
+describe('freezeValue', () => {
+  test.each([
+    ['100vh', '720px'],
+    ['50vw', '640px'],
+    ['100vmin', '720px'],
+    ['100vmax', '1280px'],
+    ['100dvh', '720px'],
+    ['100svh', '720px'],
+    ['100lvh', '720px'],
+    ['-10vh', '-72px'],
+    ['12.5vh', '90px'],
+    ['.5vh', '3.6px'],
+    ['calc(100% - 10vh)', 'calc(100% - 72px)'],
+    ['10vh 5vw', '72px 64px'],
+  ])('rewrites %s as %s', (input, expected) => {
+    expect(freezeValue(input, VIEWPORT)).toBe(expected);
+  });
+
+  test.each([
+    ['10px'],
+    ['1fr'],
+    ['url(logo100vh.png)'],
+    ['var(--x)'],
+    ['revert'],
+  ])('leaves %s alone', (input) => {
+    expect(freezeValue(input, VIEWPORT)).toBe(input);
+  });
+});
+
+describe('freezeViewportUnits', () => {
+  test('rewrites a stylesheet rule and restores it', () => {
+    const style = addStyle('.a { height: 100vh; color: red }');
+
+    const unfreeze = freezeViewportUnits(document, VIEWPORT);
+    expect(ruleOf(style).getPropertyValue('height')).toBe('720px');
+    expect(ruleOf(style).getPropertyValue('color')).toBe('red');
+
+    unfreeze();
+    expect(ruleOf(style).getPropertyValue('height')).toBe('100vh');
+  });
+
+  test('rewrites inline styles and restores them', () => {
+    const el = document.createElement('div');
+    el.setAttribute('style', 'width: 50vw');
+    document.body.appendChild(el);
+
+    const unfreeze = freezeViewportUnits(document, VIEWPORT);
+    expect(el.style.getPropertyValue('width')).toBe('640px');
+
+    unfreeze();
+    expect(el.style.getPropertyValue('width')).toBe('50vw');
+  });
+
+  test('rewrites custom properties, which is where frameworks stash lengths', () => {
+    const style = addStyle(':root { --app-height: 100vh }');
+
+    const unfreeze = freezeViewportUnits(document, VIEWPORT);
+    expect(ruleOf(style).getPropertyValue('--app-height').trim()).toBe('720px');
+
+    unfreeze();
+    expect(ruleOf(style).getPropertyValue('--app-height').trim()).toBe('100vh');
+  });
+
+  test('reaches into grouping rules such as @media', () => {
+    const style = addStyle('@media screen { .a { height: 100vh } }');
+    const media = style.sheet!.cssRules[0] as CSSMediaRule;
+
+    const unfreeze = freezeViewportUnits(document, VIEWPORT);
+    expect(
+      (media.cssRules[0] as CSSStyleRule).style.getPropertyValue('height'),
+    ).toBe('720px');
+
+    unfreeze();
+    expect(
+      (media.cssRules[0] as CSSStyleRule).style.getPropertyValue('height'),
+    ).toBe('100vh');
+  });
+
+  test('preserves !important', () => {
+    const style = addStyle('.a { height: 100vh !important }');
+
+    const unfreeze = freezeViewportUnits(document, VIEWPORT);
+    expect(ruleOf(style).getPropertyPriority('height')).toBe('important');
+    expect(ruleOf(style).getPropertyValue('height')).toBe('720px');
+
+    unfreeze();
+    expect(ruleOf(style).getPropertyValue('height')).toBe('100vh');
+    expect(ruleOf(style).getPropertyPriority('height')).toBe('important');
+  });
+
+  test('is a no-op for a document with no viewport units', () => {
+    const style = addStyle('.a { height: 400px }');
+
+    const unfreeze = freezeViewportUnits(document, VIEWPORT);
+    expect(ruleOf(style).getPropertyValue('height')).toBe('400px');
+
+    unfreeze();
+    expect(ruleOf(style).getPropertyValue('height')).toBe('400px');
+  });
+
+  test('skips a stylesheet whose rules cannot be read', () => {
+    const style = addStyle('.a { height: 100vh }');
+    Object.defineProperty(style.sheet!, 'cssRules', {
+      get() {
+        throw new DOMException('cross-origin', 'SecurityError');
+      },
+      configurable: true,
+    });
+
+    expect(() => freezeViewportUnits(document, VIEWPORT)()).not.toThrow();
+  });
+});

--- a/packages/browser/src/viewport-units.ts
+++ b/packages/browser/src/viewport-units.ts
@@ -1,0 +1,160 @@
+import type { Size } from './viewport';
+
+/**
+ * A single declaration changed by a freeze, kept so it can be put back.
+ */
+type FrozenDeclaration = [
+  style: CSSStyleDeclaration,
+  property: string,
+  value: string,
+  priority: string,
+];
+
+/**
+ * Undoes a freeze
+ */
+export type UnfreezeViewportUnits = () => void;
+
+// Matched against declaration values. The lookbehind keeps the match from
+// starting midway through an identifier, so `url(logo100vh.png)` is left
+// alone while `calc(100% - 10vh)` is not.
+const VIEWPORT_UNIT =
+  /(?<![\w.-])(-?(?:\d+\.?\d*|\.\d+))(dvh|svh|lvh|dvw|svw|lvw|vmin|vmax|vh|vw)\b/gi;
+
+const basisOf = (unit: string, { width, height }: Size): number => {
+  switch (unit.toLowerCase()) {
+    case 'vh':
+    case 'dvh':
+    case 'svh':
+    case 'lvh':
+      return height;
+    case 'vw':
+    case 'dvw':
+    case 'svw':
+    case 'lvw':
+      return width;
+    case 'vmin':
+      return Math.min(width, height);
+    default:
+      return Math.max(width, height);
+  }
+};
+
+/**
+ * Rewrites the viewport-relative lengths in a value as the pixel lengths they
+ * currently resolve to.
+ */
+export const freezeValue = (value: string, viewport: Size): string =>
+  value.replace(
+    VIEWPORT_UNIT,
+    (_, amount: string, unit: string) =>
+      `${(Number.parseFloat(amount) * basisOf(unit, viewport)) / 100}px`,
+  );
+
+const freezeDeclaration = (
+  style: CSSStyleDeclaration,
+  viewport: Size,
+  frozen: FrozenDeclaration[],
+): void => {
+  // Indexed iteration reaches custom properties too, which is where a
+  // framework often stashes a viewport-derived length.
+  for (let i = 0; i < style.length; i++) {
+    const property = style[i];
+    if (property == null) {
+      continue;
+    }
+    const value = style.getPropertyValue(property);
+    VIEWPORT_UNIT.lastIndex = 0;
+    if (!VIEWPORT_UNIT.test(value)) {
+      continue;
+    }
+    const priority = style.getPropertyPriority(property);
+    frozen.push([style, property, value, priority]);
+    style.setProperty(property, freezeValue(value, viewport), priority);
+  }
+};
+
+const freezeRules = (
+  rules: CSSRuleList,
+  viewport: Size,
+  frozen: FrozenDeclaration[],
+): void => {
+  for (const rule of Array.from(rules)) {
+    const style = (rule as CSSStyleRule).style;
+    if (style != null) {
+      freezeDeclaration(style, viewport, frozen);
+    }
+    // Covers the grouping rules — @media, @supports, @container, @layer and
+    // keyframes all nest the declarations that matter.
+    const nested = (rule as CSSGroupingRule).cssRules;
+    if (nested != null) {
+      freezeRules(nested, viewport, frozen);
+    }
+  }
+};
+
+/**
+ * Collects the document plus every open shadow root beneath it, since each
+ * carries its own stylesheets.
+ */
+const collectRoots = (document: Document): (Document | ShadowRoot)[] => {
+  const roots: (Document | ShadowRoot)[] = [document];
+  for (let i = 0; i < roots.length; i++) {
+    for (const element of Array.from(roots[i]!.querySelectorAll('*'))) {
+      if (element.shadowRoot != null) {
+        roots.push(element.shadowRoot);
+      }
+    }
+  }
+  return roots;
+};
+
+/**
+ * Pins every viewport-relative length to the pixel length it currently
+ * resolves to, and returns a function that puts them all back.
+ *
+ * Capturing a full page means growing the iframe to the height of its
+ * content, but `100vh` resolves against that same iframe, so the content
+ * grows with it and the measurement is never reached. Rewriting the units
+ * first breaks that dependency: the values written back are the ones the
+ * browser already computed, so the page renders identically, and growing the
+ * frame afterwards no longer moves the layout.
+ *
+ * Stylesheets the tester cannot read, and units applied from JavaScript
+ * rather than CSS, are out of reach here — `fitFrameToContent` re-measures
+ * afterwards rather than assuming this worked.
+ */
+export const freezeViewportUnits = (
+  document: Document,
+  viewport: Size,
+): UnfreezeViewportUnits => {
+  const frozen: FrozenDeclaration[] = [];
+
+  for (const root of collectRoots(document)) {
+    const sheets = [
+      ...Array.from(root.styleSheets ?? []),
+      ...Array.from(root.adoptedStyleSheets ?? []),
+    ];
+    for (const sheet of sheets) {
+      let rules: CSSRuleList;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        // A cross-origin stylesheet throws rather than exposing its rules.
+        continue;
+      }
+      freezeRules(rules, viewport, frozen);
+    }
+    for (const element of Array.from(root.querySelectorAll('[style]'))) {
+      freezeDeclaration((element as HTMLElement).style, viewport, frozen);
+    }
+  }
+
+  return () => {
+    // Reversed so a property written twice ends up with its original value.
+    for (const [style, property, value, priority] of frozen.reverse()) {
+      style.setProperty(property, value, priority);
+    }
+    frozen.length = 0;
+  };
+};

--- a/packages/browser/src/viewport.test.ts
+++ b/packages/browser/src/viewport.test.ts
@@ -1,0 +1,237 @@
+import { describe, test, expect, afterEach } from 'vitest';
+import {
+  fitFrameToContent,
+  getCaptureFrame,
+  measureContentSize,
+  resizeCaptureFrame,
+  type CaptureFrame,
+  type Size,
+} from './viewport';
+
+const VIEWPORT: Size = { width: 1280, height: 720 };
+
+const createFrame = (): CaptureFrame => {
+  const wrapper = document.createElement('div');
+  const frame = document.createElement('iframe');
+  wrapper.style.cssText =
+    'width: 1280px; height: 720px; transform: scale(0.8); transform-origin: left top;';
+  wrapper.appendChild(frame);
+  document.body.appendChild(wrapper);
+  return { frame, wrapper };
+};
+
+const boxOf = ({ frame }: CaptureFrame): Size => ({
+  width: Number.parseFloat(frame.style.width),
+  height: Number.parseFloat(frame.style.height),
+});
+
+/**
+ * Makes the document report a content size derived from the current iframe
+ * box, which is what lets these tests reproduce viewport-relative units.
+ */
+const stubContent = (
+  captureFrame: CaptureFrame,
+  content: (box: Size) => Size,
+) => {
+  const read = () => content(boxOf(captureFrame));
+  for (const node of [document.body, document.documentElement]) {
+    Object.defineProperty(node, 'scrollWidth', {
+      get: () => read().width,
+      configurable: true,
+    });
+    Object.defineProperty(node, 'scrollHeight', {
+      get: () => read().height,
+      configurable: true,
+    });
+  }
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('measureContentSize', () => {
+  test('takes the larger of body and documentElement', () => {
+    Object.defineProperty(document.body, 'scrollWidth', {
+      get: () => 800,
+      configurable: true,
+    });
+    Object.defineProperty(document.body, 'scrollHeight', {
+      get: () => 1400,
+      configurable: true,
+    });
+    Object.defineProperty(document.documentElement, 'scrollWidth', {
+      get: () => 1920,
+      configurable: true,
+    });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      get: () => 900,
+      configurable: true,
+    });
+
+    expect(measureContentSize(document)).toEqual({
+      width: 1920,
+      height: 1400,
+    });
+  });
+});
+
+describe('resizeCaptureFrame', () => {
+  test('sizes both the wrapper and the iframe, and drops the Vitest scale', () => {
+    const captureFrame = createFrame();
+
+    resizeCaptureFrame(captureFrame, { width: 1920, height: 1440 });
+
+    expect(captureFrame.wrapper!.style.width).toBe('1920px');
+    expect(captureFrame.wrapper!.style.height).toBe('1440px');
+    expect(captureFrame.wrapper!.style.transform).toBe('none');
+    expect(captureFrame.frame.style.width).toBe('1920px');
+    expect(captureFrame.frame.style.height).toBe('1440px');
+  });
+
+  test('sizes the iframe when there is no wrapper', () => {
+    const frame = document.createElement('iframe');
+
+    resizeCaptureFrame({ frame, wrapper: null }, { width: 640, height: 480 });
+
+    expect(frame.style.width).toBe('640px');
+    expect(frame.style.height).toBe('480px');
+  });
+});
+
+describe('getCaptureFrame', () => {
+  test('returns null when not running inside an iframe', () => {
+    expect(getCaptureFrame()).toBeNull();
+  });
+
+  test('pairs the frame with its wrapper', () => {
+    const { frame, wrapper } = createFrame();
+    Object.defineProperty(window, 'frameElement', {
+      get: () => frame,
+      configurable: true,
+    });
+
+    try {
+      expect(getCaptureFrame()).toEqual({ frame, wrapper });
+    } finally {
+      Object.defineProperty(window, 'frameElement', {
+        get: () => null,
+        configurable: true,
+      });
+    }
+  });
+});
+
+describe('fitFrameToContent', () => {
+  test('grows both axes for content with a fixed size', async () => {
+    const captureFrame = createFrame();
+    stubContent(captureFrame, () => ({ width: 1920, height: 1440 }));
+
+    const { truncated } = await fitFrameToContent(captureFrame, VIEWPORT);
+
+    expect(truncated).toEqual([]);
+    expect(boxOf(captureFrame)).toEqual({ width: 1920, height: 1440 });
+  });
+
+  test('grows the width alone when only the width overflows', async () => {
+    const captureFrame = createFrame();
+    stubContent(captureFrame, () => ({ width: 1920, height: 300 }));
+
+    const { truncated } = await fitFrameToContent(captureFrame, VIEWPORT);
+
+    expect(truncated).toEqual([]);
+    // Never shrinks below the viewport, matching Playwright's own `fullPage`.
+    expect(boxOf(captureFrame)).toEqual({ width: 1920, height: 720 });
+  });
+
+  test('keeps the viewport box when the content fits', async () => {
+    const captureFrame = createFrame();
+    stubContent(captureFrame, () => ({ width: 1000, height: 400 }));
+
+    const { truncated } = await fitFrameToContent(captureFrame, VIEWPORT);
+
+    expect(truncated).toEqual([]);
+    expect(boxOf(captureFrame)).toEqual(VIEWPORT);
+  });
+
+  test('rolls back a height that keeps following the frame', async () => {
+    const captureFrame = createFrame();
+    // Stands in for a height JavaScript recomputes from window.innerHeight,
+    // which freezing the CSS units cannot reach.
+    stubContent(captureFrame, (box) => ({
+      width: box.width,
+      height: box.height * 2,
+    }));
+
+    const { truncated } = await fitFrameToContent(captureFrame, VIEWPORT);
+
+    expect(truncated).toEqual(['height']);
+    expect(boxOf(captureFrame)).toEqual(VIEWPORT);
+  });
+
+  test('keeps a grown width while rolling back an unstable height', async () => {
+    const captureFrame = createFrame();
+    stubContent(captureFrame, (box) => ({
+      width: 1920,
+      height: box.height * 2,
+    }));
+
+    const { truncated } = await fitFrameToContent(captureFrame, VIEWPORT);
+
+    expect(truncated).toEqual(['height']);
+    expect(boxOf(captureFrame)).toEqual({ width: 1920, height: 720 });
+  });
+
+  test('rolls back an unstable width and keeps a stable height', async () => {
+    const captureFrame = createFrame();
+    stubContent(captureFrame, (box) => ({
+      width: box.width * 1.5,
+      height: 1440,
+    }));
+
+    const { truncated } = await fitFrameToContent(captureFrame, VIEWPORT);
+
+    expect(truncated).toEqual(['width']);
+    expect(boxOf(captureFrame)).toEqual({ width: 1280, height: 1440 });
+  });
+
+  test('freezes viewport units so `100vh` content can be grown into', async () => {
+    const captureFrame = createFrame();
+    const style = document.createElement('style');
+    style.textContent = '.section { height: 100vh }';
+    document.head.appendChild(style);
+
+    // Reproduces the real feedback loop: two 100vh sections, where the
+    // content height tracks whatever the CSS currently resolves to.
+    const sectionHeight = () => {
+      const rule = (style.sheet!.cssRules[0] as CSSStyleRule).style;
+      const value = rule.getPropertyValue('height');
+      return value.endsWith('vh')
+        ? (Number.parseFloat(value) / 100) * boxOf(captureFrame).height
+        : Number.parseFloat(value);
+    };
+    stubContent(captureFrame, () => ({
+      width: 1280,
+      height: sectionHeight() * 2,
+    }));
+
+    try {
+      const { truncated, unfreeze } = await fitFrameToContent(
+        captureFrame,
+        VIEWPORT,
+      );
+
+      expect(truncated).toEqual([]);
+      expect(boxOf(captureFrame)).toEqual({ width: 1280, height: 1440 });
+
+      unfreeze();
+      expect(
+        (style.sheet!.cssRules[0] as CSSStyleRule).style.getPropertyValue(
+          'height',
+        ),
+      ).toBe('100vh');
+    } finally {
+      style.remove();
+    }
+  });
+});

--- a/packages/browser/src/viewport.ts
+++ b/packages/browser/src/viewport.ts
@@ -1,0 +1,144 @@
+import {
+  freezeViewportUnits,
+  type UnfreezeViewportUnits,
+} from './viewport-units';
+
+/**
+ * A width/height pair in CSS pixels
+ */
+export type Size = {
+  width: number;
+  height: number;
+};
+
+/**
+ * The iframe the story renders in, together with the wrapper Vitest sizes and
+ * scales it through.
+ */
+export type CaptureFrame = {
+  frame: HTMLIFrameElement;
+  wrapper: HTMLElement | null;
+};
+
+/**
+ * Resolves the iframe the current tester runs in.
+ *
+ * Vitest serves the tester same-origin, so `window.frameElement` reaches the
+ * orchestrator's iframe element directly and the resizing below needs no
+ * round trip to Node.
+ */
+export const getCaptureFrame = (): CaptureFrame | null => {
+  const frame = window.frameElement as HTMLIFrameElement | null;
+  if (frame == null) {
+    return null;
+  }
+  return { frame, wrapper: frame.parentElement };
+};
+
+/**
+ * Measures the size the content occupies, including anything overflowing the
+ * current viewport.
+ */
+export const measureContentSize = (document: Document): Size => ({
+  width: Math.max(
+    document.body.scrollWidth,
+    document.documentElement.scrollWidth,
+  ),
+  height: Math.max(
+    document.body.scrollHeight,
+    document.documentElement.scrollHeight,
+  ),
+});
+
+/**
+ * Sizes the iframe box.
+ *
+ * The wrapper carries the `transform: scale()` Vitest applies to fit the
+ * iframe on screen; leaving it in place would scale the capture down, so it is
+ * reset alongside the size. The iframe itself is sized too, both because a
+ * stylesheet rule stretches it to `100%` and so that this still works if a
+ * future Vitest drops the wrapper.
+ */
+export const resizeCaptureFrame = (
+  { frame, wrapper }: CaptureFrame,
+  { width, height }: Size,
+): void => {
+  if (wrapper != null) {
+    wrapper.style.cssText = `width: ${width}px; height: ${height}px; transform: none; transform-origin: left top;`;
+  }
+  frame.style.setProperty('width', `${width}px`, 'important');
+  frame.style.setProperty('height', `${height}px`, 'important');
+};
+
+/**
+ * Waits for the browser to lay out and paint the pending size change.
+ */
+export const waitForReflow = async (): Promise<void> => {
+  void document.documentElement.offsetHeight;
+  await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+};
+
+/**
+ * The outcome of fitting the frame to its content.
+ *
+ * `unfreeze` must be called once the capture is done. `truncated` names the
+ * axes the content still overflows, which only happens when something outside
+ * this module's reach keeps the layout tied to the viewport.
+ */
+export type FitResult = {
+  unfreeze: UnfreezeViewportUnits;
+  truncated: ('width' | 'height')[];
+};
+
+/**
+ * Grows the iframe so its outer box matches the content it holds, which lets a
+ * single Playwright element screenshot capture everything, with no scrolling,
+ * tiling or stitching.
+ *
+ * Growing is only sound once the layout no longer depends on the box being
+ * grown, so viewport-relative units are pinned first — see
+ * `freezeViewportUnits`. That covers units written in CSS; a length computed
+ * in JavaScript from `window.innerHeight`, or one in a stylesheet the tester
+ * cannot read, still moves. So the grown box is verified against a fresh
+ * measurement and any axis that moved is rolled back to the viewport, which
+ * keeps the story rendering the way it does today at the cost of a capture
+ * cropped to that axis.
+ */
+export const fitFrameToContent = async (
+  captureFrame: CaptureFrame,
+  viewport: Size,
+): Promise<FitResult> => {
+  const unfreeze = freezeViewportUnits(document, viewport);
+
+  const content = measureContentSize(document);
+  const grown = {
+    width: Math.max(content.width, viewport.width),
+    height: Math.max(content.height, viewport.height),
+  };
+
+  resizeCaptureFrame(captureFrame, grown);
+  await waitForReflow();
+
+  const verified = measureContentSize(document);
+  const settled = {
+    width: verified.width === grown.width ? grown.width : viewport.width,
+    height: verified.height === grown.height ? grown.height : viewport.height,
+  };
+
+  if (settled.width !== grown.width || settled.height !== grown.height) {
+    resizeCaptureFrame(captureFrame, settled);
+    await waitForReflow();
+  }
+
+  const remaining = measureContentSize(document);
+  const truncated: ('width' | 'height')[] = [];
+  if (remaining.width > settled.width) {
+    truncated.push('width');
+  }
+  if (remaining.height > settled.height) {
+    truncated.push('height');
+  }
+
+  return { unfreeze, truncated };
+};

--- a/packages/browser/src/vitest-plugin/index.test.ts
+++ b/packages/browser/src/vitest-plugin/index.test.ts
@@ -8,117 +8,107 @@ const getCommands = (options?: Parameters<typeof storycap>[0]) => {
   return plugin.config().test.browser.commands;
 };
 
-const createMockContext = (initialViewport: Viewport | null) => {
-  let current = initialViewport;
+const createMockContext = (pageViewport: Viewport | null) => {
+  const screenshot = vi.fn(async () => Buffer.from('png'));
   const page = {
-    viewportSize: vi.fn(() => current),
-    setViewportSize: vi.fn(async (viewport: Viewport) => {
-      current = viewport;
-    }),
-    evaluate: vi.fn(async () => 'original-style'),
+    viewportSize: vi.fn(() => pageViewport),
+    locator: vi.fn(() => ({ screenshot })),
   };
-  return { page } as any;
+  const iframe = {
+    locator: vi.fn(() => ({ screenshot })),
+  };
+  return { context: { page, iframe } as any, screenshot };
 };
 
-describe('__storycap_prepareViewport', () => {
+describe('__storycap_resolveViewport', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test('resizes to the plugin viewport when it differs from the page', async () => {
-    const commands = getCommands({
-      viewport: { width: 1366, height: 600 },
-    });
-    const context = createMockContext({ width: 1280, height: 720 });
+  test('uses the plugin viewport over the page viewport', async () => {
+    const commands = getCommands({ viewport: { width: 1366, height: 600 } });
+    const { context } = createMockContext({ width: 1280, height: 720 });
 
-    await commands.__storycap_prepareViewport(context);
-
-    expect(context.page.setViewportSize).toHaveBeenCalledWith({
-      width: 1366,
-      height: 600,
-    });
+    await expect(commands.__storycap_resolveViewport(context)).resolves.toEqual(
+      { width: 1366, height: 600 },
+    );
   });
 
   test('per-story override wins over the plugin viewport', async () => {
-    const commands = getCommands({
-      viewport: { width: 1366, height: 600 },
-    });
-    const context = createMockContext({ width: 1366, height: 600 });
+    const commands = getCommands({ viewport: { width: 1366, height: 600 } });
+    const { context } = createMockContext({ width: 1366, height: 600 });
 
-    await commands.__storycap_prepareViewport(context, {
-      width: 375,
-      height: 800,
-    });
-
-    expect(context.page.setViewportSize).toHaveBeenCalledWith({
-      width: 375,
-      height: 800,
-    });
+    await expect(
+      commands.__storycap_resolveViewport(context, { width: 375, height: 800 }),
+    ).resolves.toEqual({ width: 375, height: 800 });
   });
 
   test('partial override keeps the other dimension from the plugin viewport', async () => {
-    const commands = getCommands({
-      viewport: { width: 1366, height: 600 },
-    });
-    const context = createMockContext({ width: 1366, height: 600 });
+    const commands = getCommands({ viewport: { width: 1366, height: 600 } });
+    const { context } = createMockContext({ width: 1366, height: 600 });
 
-    await commands.__storycap_prepareViewport(context, { height: 800 });
-
-    expect(context.page.setViewportSize).toHaveBeenCalledWith({
-      width: 1366,
-      height: 800,
-    });
+    await expect(
+      commands.__storycap_resolveViewport(context, { height: 800 }),
+    ).resolves.toEqual({ width: 1366, height: 800 });
   });
 
   test('partial override falls back to the page viewport without a plugin viewport', async () => {
     const commands = getCommands();
-    const context = createMockContext({ width: 1280, height: 720 });
+    const { context } = createMockContext({ width: 1280, height: 720 });
 
-    await commands.__storycap_prepareViewport(context, { height: 800 });
+    await expect(
+      commands.__storycap_resolveViewport(context, { height: 800 }),
+    ).resolves.toEqual({ width: 1280, height: 800 });
+  });
 
-    expect(context.page.setViewportSize).toHaveBeenCalledWith({
+  test('falls back to a default when neither a plugin nor a page viewport exists', async () => {
+    const commands = getCommands();
+    const { context } = createMockContext(null);
+
+    await expect(commands.__storycap_resolveViewport(context)).resolves.toEqual(
+      { width: 1280, height: 720 },
+    );
+  });
+});
+
+describe('__storycap_takeScreenshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('captures the iframe element, which the tester already sized', async () => {
+    const commands = getCommands();
+    const { context } = createMockContext({ width: 1280, height: 720 });
+
+    await commands.__storycap_takeScreenshot(
+      context,
+      `${process.cwd()}/__screenshots__/tmp/iframe.png`,
+      { type: 'png' },
+    );
+
+    expect(context.page.locator).toHaveBeenCalledWith('iframe[data-vitest]');
+    expect(context.iframe.locator).not.toHaveBeenCalled();
+  });
+
+  test('forwards image options and omits the ones left unset', async () => {
+    const commands = getCommands();
+    const { context, screenshot } = createMockContext({
       width: 1280,
-      height: 800,
+      height: 720,
     });
-  });
 
-  test('does not resize when the override matches the current viewport', async () => {
-    const commands = getCommands({
-      viewport: { width: 1366, height: 600 },
+    await commands.__storycap_takeScreenshot(
+      context,
+      `${process.cwd()}/__screenshots__/tmp/options.png`,
+      { type: 'jpeg', scale: 'css' },
+    );
+
+    expect(screenshot).toHaveBeenCalledWith({
+      animations: 'disabled',
+      caret: 'hide',
+      scale: 'css',
+      type: 'jpeg',
     });
-    const context = createMockContext({ width: 1366, height: 600 });
-
-    await commands.__storycap_prepareViewport(context, { height: 600 });
-
-    expect(context.page.setViewportSize).not.toHaveBeenCalled();
-  });
-
-  test('restoreViewport undoes an override resize', async () => {
-    const commands = getCommands({
-      viewport: { width: 1366, height: 600 },
-    });
-    const context = createMockContext({ width: 1366, height: 600 });
-
-    await commands.__storycap_prepareViewport(context, { height: 800 });
-    await commands.__storycap_restoreViewport(context);
-
-    expect(context.page.setViewportSize).toHaveBeenLastCalledWith({
-      width: 1366,
-      height: 600,
-    });
-  });
-
-  test('sizes the iframe wrapper to the resolved viewport', async () => {
-    const commands = getCommands({
-      viewport: { width: 1366, height: 600 },
-    });
-    const context = createMockContext({ width: 1366, height: 600 });
-
-    await commands.__storycap_prepareViewport(context, { height: 800 });
-
-    expect(context.page.evaluate).toHaveBeenCalledWith(expect.any(Function), {
-      w: 1366,
-      h: 800,
-    });
+    expect(context.page.locator).toHaveBeenCalled();
   });
 });

--- a/packages/browser/src/vitest-plugin/index.ts
+++ b/packages/browser/src/vitest-plugin/index.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { BrowserCommand, BrowserCommandContext } from 'vitest/node';
+import type { BrowserCommand } from 'vitest/node';
 import type { Plugin } from 'vitest/config';
 import {
   resolveScreenshotFilename,
@@ -25,35 +25,17 @@ const createResolveScreenshotFilepath =
 export type TakeScreenshotParams = [
   filepath: string,
   options: {
-    fullPage?: boolean;
     omitBackground?: boolean;
     scale?: 'css' | 'device';
     type?: 'jpeg' | 'png';
-    viewport?: ScreenshotViewportConfig | null;
   },
 ];
 export type TakeScreenshotResult = Promise<string>;
 
-export type PrepareViewportParams = [
+export type ResolveViewportParams = [
   viewportOverride?: ScreenshotViewportConfig | null,
 ];
-export type PrepareViewportResult = Promise<void>;
-
-export type RestoreViewportParams = [];
-export type RestoreViewportResult = Promise<void>;
-
-type CaptureState = {
-  wrapperStyle: string | null;
-  previousViewport: { width: number; height: number } | null;
-};
-
-// Test files get their own page and run concurrently, so prepareViewport and
-// restoreViewport calls interleave. Keying the state by page keeps each capture
-// from restoring another page's values.
-const captureStates = new WeakMap<
-  BrowserCommandContext['page'],
-  CaptureState
->();
+export type ResolveViewportResult = Promise<{ width: number; height: number }>;
 
 /**
  * Resolves the viewport a capture is taken at. A per-story override wins over
@@ -73,157 +55,37 @@ const resolveCaptureViewport = (
 };
 
 /**
- * Prepares the iframe viewport for screenshot capture.
- * Sets the iframe wrapper to the configured viewport size with `transform: none`.
- * Must be called before any hooks so that mask positions and user hooks
- * see the correct layout dimensions.
+ * Reports the viewport the capture should be laid out at. Resolving happens
+ * here because the plugin viewport option only exists on the Node side; the
+ * tester applies the result to the iframe itself.
  */
-const createPrepareViewport =
+const createResolveViewport =
   (pluginViewport?: {
     width: number;
     height: number;
-  }): BrowserCommand<PrepareViewportParams> =>
-  async (context, viewportOverride): PrepareViewportResult => {
-    const previousViewport = context.page.viewportSize();
-    const viewport = resolveCaptureViewport(
+  }): BrowserCommand<ResolveViewportParams> =>
+  async (context, viewportOverride): ResolveViewportResult =>
+    resolveCaptureViewport(
       pluginViewport,
-      previousViewport,
+      context.page.viewportSize(),
       viewportOverride,
     );
 
-    // Playwright intersects a screenshot `clip` with the browser viewport, so a
-    // configured viewport wider or taller than the Playwright context viewport
-    // would be silently cropped. Resizing the context keeps layout, clipping
-    // and stitching in one coordinate space.
-    //
-    // A null viewport means emulation is off and the page follows the real
-    // window; enabling emulation there cannot be undone, so it only happens for
-    // a viewport the caller actually asked for.
-    const hasOverride =
-      viewportOverride?.width != null || viewportOverride?.height != null;
-    const resized =
-      previousViewport == null
-        ? pluginViewport != null || hasOverride
-        : previousViewport.width !== viewport.width ||
-          previousViewport.height !== viewport.height;
-
-    if (resized) {
-      await context.page.setViewportSize(viewport);
-    }
-
-    // Recorded before the wrapper is touched so a failure there still leaves
-    // restoreViewport able to undo the resize.
-    const state: CaptureState = {
-      wrapperStyle: null,
-      previousViewport: resized ? previousViewport : null,
-    };
-    captureStates.set(context.page, state);
-
-    state.wrapperStyle = await context.page.evaluate(
-      ({ w, h }) => {
-        const iframe = document.querySelector(
-          'iframe[data-vitest]',
-        ) as HTMLIFrameElement | null;
-        const wrapper = iframe?.parentElement;
-        if (!wrapper) return null;
-
-        const original = wrapper.style.cssText;
-        wrapper.style.cssText = `width: ${w}px; height: ${h}px; transform: none; transform-origin: left top;`;
-        return original;
-      },
-      { w: viewport.width, h: viewport.height },
-    );
-  };
-
 /**
- * Restores the iframe wrapper to its original state after screenshot capture.
+ * Creates a browser command that takes screenshots.
+ *
+ * The tester has already sized the iframe to exactly the region to capture,
+ * so this is a plain Playwright element screenshot. Playwright captures
+ * beyond the viewport, so an iframe grown past the Playwright context
+ * viewport still comes back whole, and no scrolling, tiling or clip
+ * arithmetic is needed here.
  */
-const restoreViewport: BrowserCommand<RestoreViewportParams> = async (
-  context,
-): RestoreViewportResult => {
-  const state = captureStates.get(context.page);
-  if (state == null) {
-    return;
-  }
-  captureStates.delete(context.page);
-
-  try {
-    if (state.wrapperStyle != null) {
-      await context.page.evaluate((css) => {
-        const iframe = document.querySelector(
-          'iframe[data-vitest]',
-        ) as HTMLIFrameElement | null;
-        if (iframe?.parentElement) {
-          iframe.parentElement.style.cssText = css;
-        }
-      }, state.wrapperStyle);
-    }
-  } finally {
-    // The state is already gone from the map, so a failure above would
-    // otherwise leave the page resized for every later capture.
-    if (state.previousViewport != null) {
-      await context.page.setViewportSize(state.previousViewport);
-    }
-  }
-};
-
-/**
- * Captures a full-page screenshot by scrolling through the iframe and stitching
- * viewport-sized clips using the browser's Canvas API. Content wider than the
- * viewport is covered by scrolling horizontally as well, tiling row by row.
- */
-async function captureFullPage(
-  context: Parameters<BrowserCommand<TakeScreenshotParams>>[0],
-  viewport: { width: number; height: number },
-  scrollSize: { width: number; height: number },
-  options: TakeScreenshotParams[1],
-): Promise<Buffer> {
-  const chunks: string[] = [];
-  const columns = Math.ceil(scrollSize.width / viewport.width);
-
-  for (
-    let scrollY = 0;
-    scrollY < scrollSize.height;
-    scrollY += viewport.height
-  ) {
-    for (
-      let scrollX = 0;
-      scrollX < scrollSize.width;
-      scrollX += viewport.width
-    ) {
-      // The browser clamps a scroll past the edge, so the requested offset is
-      // read back rather than assumed: the last chunk sits at the bottom/right
-      // edge of the viewport, not at its top/left.
-      const reached = await context.iframe.locator('body').evaluate(
-        (body, { x, y }) => {
-          const view = body.ownerDocument.defaultView;
-          // A story that sets `scroll-behavior: smooth` would otherwise leave the
-          // read-back on the pre-scroll position.
-          view?.scrollTo({ top: y, left: x, behavior: 'instant' });
-          return { x: view?.scrollX ?? 0, y: view?.scrollY ?? 0 };
-        },
-        { x: scrollX, y: scrollY },
-      );
-
-      const chunkW = Math.min(viewport.width, scrollSize.width - scrollX);
-      const chunkH = Math.min(viewport.height, scrollSize.height - scrollY);
-
-      const iframeBox = await context.page
-        .locator('iframe[data-vitest]')
-        .boundingBox();
-      if (!iframeBox) {
-        throw new Error(
-          'Could not determine iframe position for full-page screenshot',
-        );
-      }
-
-      const chunkBuf = await context.page.screenshot({
-        clip: {
-          x: iframeBox.x + (scrollX - reached.x),
-          y: iframeBox.y + (scrollY - reached.y),
-          width: chunkW,
-          height: chunkH,
-        },
+const createTakeScreenshot =
+  (): BrowserCommand<TakeScreenshotParams> =>
+  async (context, filepath, options): TakeScreenshotResult => {
+    const buffer = await context.page
+      .locator('iframe[data-vitest]')
+      .screenshot({
         animations: 'disabled',
         caret: 'hide',
         ...(options.omitBackground != null && {
@@ -233,164 +95,10 @@ async function captureFullPage(
         ...(options.type != null && { type: options.type }),
       });
 
-      chunks.push(Buffer.from(chunkBuf).toString('base64'));
-    }
-  }
-
-  // Stitch chunks using browser-native Canvas API (no external dependency)
-  const mimeType = options.type === 'jpeg' ? 'image/jpeg' : 'image/png';
-  const stitchedB64 = await context.page.evaluate(
-    async ({ images, columns: cols, mime }) => {
-      // Sizing the canvas from the decoded chunks rather than the CSS-pixel
-      // viewport keeps the stitched image correct under a `deviceScaleFactor`
-      // other than 1, where each chunk comes back scaled.
-      const decoded = await Promise.all(
-        images.map(
-          (src, index) =>
-            new Promise<HTMLImageElement>((resolve, reject) => {
-              const img = new Image();
-              img.onload = () => resolve(img);
-              img.onerror = () =>
-                reject(
-                  new Error(`Failed to decode screenshot chunk ${index}.`),
-                );
-              img.src = `data:${mime};base64,${src}`;
-            }),
-        ),
-      );
-
-      const firstRow = decoded.slice(0, cols);
-      const firstColumn = decoded.filter((_, index) => index % cols === 0);
-      const canvas = document.createElement('canvas');
-      canvas.width = firstRow.reduce((sum, img) => sum + img.naturalWidth, 0);
-      canvas.height = firstColumn.reduce(
-        (sum, img) => sum + img.naturalHeight,
-        0,
-      );
-      const ctx = canvas.getContext('2d')!;
-
-      let y = 0;
-      for (let row = 0; row * cols < decoded.length; row += 1) {
-        const rowImages = decoded.slice(row * cols, (row + 1) * cols);
-        let x = 0;
-        for (const img of rowImages) {
-          ctx.drawImage(img, x, y);
-          x += img.naturalWidth;
-        }
-        y += rowImages[0]!.naturalHeight;
-      }
-
-      // A canvas past the browser's maximum dimensions yields an empty data URL,
-      // which would otherwise be written out as a zero-byte screenshot.
-      const encoded = canvas.toDataURL(mime).split(',')[1];
-      if (!encoded) {
-        throw new Error(
-          `Failed to encode a ${canvas.width}x${canvas.height} full-page screenshot; the canvas likely exceeds the browser's maximum size.`,
-        );
-      }
-      return encoded;
-    },
-    { images: chunks, columns, mime: mimeType },
-  );
-
-  // Restore scroll position
-  await context.iframe.locator('body').evaluate((body) =>
-    body.ownerDocument.defaultView?.scrollTo({
-      top: 0,
-      left: 0,
-      behavior: 'instant',
-    }),
-  );
-
-  return Buffer.from(stitchedB64, 'base64');
-}
-
-/**
- * Creates a browser command that takes screenshots.
- * The iframe wrapper CSS is already adjusted by prepareViewport before this runs.
- */
-const createTakeScreenshot =
-  (pluginViewport?: {
-    width: number;
-    height: number;
-  }): BrowserCommand<TakeScreenshotParams> =>
-  async (context, filepath, options): TakeScreenshotResult => {
-    const viewport = resolveCaptureViewport(
-      pluginViewport,
-      context.page.viewportSize(),
-      options.viewport,
-    );
-
-    let buffer: Buffer;
-
-    if (options.fullPage === false) {
-      // Viewport-only capture via clip on the orchestrator page
-      await context.page.evaluate(() => window.scrollTo(0, 0));
-
-      const iframeBox = await context.page
-        .locator('iframe[data-vitest]')
-        .boundingBox();
-      if (!iframeBox) {
-        throw new Error(
-          'Could not determine iframe position for viewport screenshot',
-        );
-      }
-
-      buffer = Buffer.from(
-        await context.page.screenshot({
-          animations: 'disabled',
-          caret: 'hide',
-          clip: {
-            x: iframeBox.x,
-            y: iframeBox.y,
-            width: iframeBox.width,
-            height: iframeBox.height,
-          },
-          ...(options.omitBackground != null && {
-            omitBackground: options.omitBackground,
-          }),
-          ...(options.scale != null && { scale: options.scale }),
-          ...(options.type != null && { type: options.type }),
-        }),
-      );
-    } else {
-      // Full-page capture: stitch if content exceeds viewport in either axis
-      const scrollSize = await context.iframe
-        .locator('body')
-        .evaluate((body) => {
-          const documentElement = body.ownerDocument.documentElement;
-          return {
-            width: Math.max(body.scrollWidth, documentElement.scrollWidth),
-            height: Math.max(body.scrollHeight, documentElement.scrollHeight),
-          };
-        });
-
-      if (
-        scrollSize.height > viewport.height ||
-        scrollSize.width > viewport.width
-      ) {
-        buffer = await captureFullPage(context, viewport, scrollSize, options);
-      } else {
-        const screenshotOptions: Parameters<
-          ReturnType<typeof context.iframe.locator>['screenshot']
-        >[0] = {
-          animations: 'disabled',
-          caret: 'hide',
-        };
-        if (options.omitBackground != null)
-          screenshotOptions.omitBackground = options.omitBackground;
-        if (options.scale != null) screenshotOptions.scale = options.scale;
-        if (options.type != null) screenshotOptions.type = options.type;
-        buffer = await context.iframe
-          .locator('body')
-          .screenshot(screenshotOptions);
-      }
-    }
-
     await fs.mkdir(path.dirname(filepath), { recursive: true });
     await fs.writeFile(filepath, buffer);
 
-    return Buffer.from(buffer).toString('base64');
+    return buffer.toString('base64');
   };
 
 /**
@@ -426,9 +134,8 @@ export default function vitestStorycapPluginOptions(
               resolveScreenshotFilepath: createResolveScreenshotFilepath(
                 opts.output,
               ),
-              __storycap_takeScreenshot: createTakeScreenshot(opts.viewport),
-              __storycap_prepareViewport: createPrepareViewport(opts.viewport),
-              __storycap_restoreViewport: restoreViewport,
+              __storycap_takeScreenshot: createTakeScreenshot(),
+              __storycap_resolveViewport: createResolveViewport(opts.viewport),
             },
           },
         },

--- a/packages/internal/src/screenshot.ts
+++ b/packages/internal/src/screenshot.ts
@@ -263,6 +263,19 @@ export type ScreenshotAdapter<
   ) => Promise<void>;
 
   /**
+   * Grows the capture surface to fit the page content.
+   *
+   * Runs once the page is stable, so the content measurement is not taken
+   * while fonts and images are still reflowing, but before hooks.preCapture()
+   * so that masks are positioned against the layout that gets captured.
+   */
+  fitCaptureToContent?: (
+    page: Page,
+    context: SContext,
+    options: { fullPage: boolean },
+  ) => Promise<void>;
+
+  /**
    * Restores the capture environment after the full capture flow completes.
    * Always called in a finally block to guarantee cleanup even on errors.
    */
@@ -323,15 +336,6 @@ export const createScreenshotFunction = <
         await sleep(params.delay);
       }
 
-      await processor.preCapture(page, ctx);
-
-      const filepath = await adapter.resolveFilepath(ctx);
-      const type = JPEG_EXTENSIONS.has(
-        filepath.slice(filepath.lastIndexOf('.')),
-      )
-        ? 'jpeg'
-        : 'png';
-
       const imageOptions = {
         ...opts.image,
         ...(params.fullPage != null && { fullPage: params.fullPage }),
@@ -340,6 +344,19 @@ export const createScreenshotFunction = <
         }),
         ...(params.scale != null && { scale: params.scale }),
       };
+
+      await adapter.fitCaptureToContent?.(page, ctx, {
+        fullPage: imageOptions.fullPage,
+      });
+
+      await processor.preCapture(page, ctx);
+
+      const filepath = await adapter.resolveFilepath(ctx);
+      const type = JPEG_EXTENSIONS.has(
+        filepath.slice(filepath.lastIndexOf('.')),
+      )
+        ? 'jpeg'
+        : 'png';
 
       await retakeScreenshotIfNeeded(
         async () => {


### PR DESCRIPTION
## What was wrong

Full-page screenshots stitch together multiple viewport-height segments as the page scrolls. `position: sticky` and `position: fixed` elements stay pinned and appear multiple times #297.

## What changed

Before each segment capture, vw/vh elements are frozen to viewport px sizes and iframe is set to max scroll height width, so we can do fullPage capture through playwright.